### PR TITLE
Use a DNS lookup instead of an HTTP request to verify that telemetry servers are not available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 minreq = { version = "2.7.0", features = ["json-using-serde", "https-rustls-probe"] }
+dns-lookup = "1.0.8"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/check_domain.rs
+++ b/src/check_domain.rs
@@ -3,11 +3,6 @@
 /// Timeout is optional amount of seconds
 #[tracing::instrument(level = "trace")]
 pub fn available<T: AsRef<str> + std::fmt::Debug>(domain: T, timeout: Option<u64>) -> bool {
-    let mut request = minreq::head(format!("http://{}", domain.as_ref()));
-
-    if let Some(timeout) = timeout {
-        request = request.with_timeout(timeout);
-    }
-
-    request.send().is_ok()
+    let ips = dns_lookup::lookup_host(domain.as_ref()).unwrap();
+    !ips.contains(&"0.0.0.0".parse().unwrap())
 }


### PR DESCRIPTION
Use `dns-lookup` to verify that telemetry servers are blocked. This should allow using the launcher on systems with a running HTTP server.

I hope that I didn't introduce some kind of dependency hell with this.