### PR TITLE
fix: fix typo "availale"

### DIFF
--- a/src/installer/downloader.rs
+++ b/src/installer/downloader.rs
@@ -22,7 +22,7 @@ pub enum DownloadingError {
     /// No free space available under specified path
     ///
     /// `(path, required, available)`
-    #[error("No free space availale for specified path: {0:?} (requires {}, available {})", prettify_bytes(*.1), prettify_bytes(*.2))]
+    #[error("No free space available for specified path: {0:?} (requires {}, available {})", prettify_bytes(*.1), prettify_bytes(*.2))]
     NoSpaceAvailable(PathBuf, u64, u64),
 
     /// Failed to create or open output file


### PR DESCRIPTION
Hi all! Just changed it to "available"

Yep, that's all ( —ᴗ—)