### PR TITLE
Download globalgamemanagers last, then update .version

### DIFF
--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -247,6 +247,16 @@ impl VersionDiff {
 
         installer.install(path.as_ref(), move |msg| { (updater)(msg.into()) })?;
 
+        // Create `.version` file here even if hdiff patching is failed because
+        // it's easier to explain user why he should run files repairer than
+        // why he should re-download entire game update because something is failed
+        #[allow(unused_must_use)] {
+            let version_path = self.version_file_path()
+                .unwrap_or(path.as_ref().join(".version"));
+
+            std::fs::write(version_path, self.latest().version);
+        }
+
         Ok(())
     }
 
@@ -254,7 +264,17 @@ impl VersionDiff {
         let client = reqwest::blocking::Client::new();
         let patcher = sophon::updater::SophonPatcher::new(diff, client, self.temp_folder())?;
 
-        patcher.sophon_apply_patches(path, from, move |msg | (updater)(msg.into()))?;
+        patcher.sophon_apply_patches(&path, from, move |msg | (updater)(msg.into()))?;
+
+        // Create `.version` file here even if hdiff patching is failed because
+        // it's easier to explain user why he should run files repairer than
+        // why he should re-download entire game update because something is failed
+        #[allow(unused_must_use)] {
+            let version_path = self.version_file_path()
+                .unwrap_or(path.as_ref().join(".version"));
+
+            std::fs::write(version_path, self.latest().version);
+        }
 
         Ok(())
     }

--- a/src/sophon/installer.rs
+++ b/src/sophon/installer.rs
@@ -268,15 +268,25 @@ impl SophonInstaller {
         progress: &mut DownloadProgress
     ) {
         for asset_file in &self.manifest.Assets {
-            match self.download_chunked_file(output_folder, asset_file, updater.clone(), progress) {
-                Ok(()) => {
-                    progress.downloaded_files += 1;
-
-                    (updater)(progress.msg_files());
-                }
-
-                Err(e) => (updater)(Update::DownloadingError(e))
+            if asset_file.AssetName.ends_with("globalgamemanagers") {
+                continue;
             }
+            self.download_file_updater_handler(output_folder, asset_file, updater.clone(), progress);
+        }
+        if let Some(asset_file) = self.manifest.Assets.iter().find(|asset| asset.AssetName.ends_with("globalgamemanagers")) {
+            self.download_file_updater_handler(output_folder, asset_file, updater.clone(), progress);
+        }
+    }
+
+    fn download_file_updater_handler(&self, output_folder: &Path, asset_file: &SophonManifestAssetProperty, updater: impl Fn(Update) + Clone + Send + 'static, progress: &mut DownloadProgress) {
+        match self.download_chunked_file(output_folder, asset_file, updater.clone(), progress) {
+            Ok(()) => {
+                progress.downloaded_files += 1;
+
+                (updater)(progress.msg_files());
+            }
+
+            Err(e) => (updater)(Update::DownloadingError(e))
         }
     }
 


### PR DESCRIPTION
`.version` is updated after the installer/patcher exits, and the main loop for downloading/patching ignores `globalgamemanagers` which is then downloaded/patched after it.