### PR TITLE
Sophon fixes and optimizations

### DIFF
--- a/src/sophon/updater.rs
+++ b/src/sophon/updater.rs
@@ -1,23 +1,18 @@
-use std::collections::{HashMap, HashSet};
+use std::{collections::{HashMap, HashSet}, io::{Read, Seek, Take}};
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::os::unix::fs::FileExt;
 
 use serde::{Deserialize, Serialize};
 use reqwest::blocking::Client;
 
 // I ain't refactoring it.
 use super::{
-    api_post_request,
-    api_schemas::{
+    api_post_request, api_schemas::{
         game_branches::PackageInfo,
         sophon_diff::{SophonDiff, SophonDiffs},
-    },
-    get_protobuf_from_url, md5_hash_str,
-    protos::SophonPatch::{
-        self, SophonPatchAssetChunk, SophonPatchAssetProperty, SophonPatchProto, SophonUnusedAssetFile
-    },
-    GameEdition, SophonError,
+    }, file_md5_hash_str, get_protobuf_from_url, md5_hash_str, protos::SophonPatch::{
+        SophonPatchAssetChunk, SophonPatchAssetProperty, SophonPatchProto, SophonUnusedAssetFile
+    }, GameEdition, SophonError
 };
 
 use crate::{
@@ -449,17 +444,11 @@ impl SophonPatcher {
 
         let patch_chunk_file = self.download_patch_chunk(patch_chunk, progress, updater.clone())?;
 
-        let patch_data = extract_patch_chunk_region(
-            patch_chunk_file,
-            patch_chunk.PatchOffset,
-            patch_chunk.PatchLength,
-        )?;
-
         let patch_path_tmp = self.temp_folder.join(
             format!("{}-{}.hdiff",patch_chunk.OriginalFileMd5, asset_info.AssetHashMd5)
         );
 
-        std::fs::write(&patch_path_tmp, &patch_data)?;
+        extract_patch_chunk_region_to_file(patch_chunk_file, &patch_path_tmp, patch_chunk)?;
 
         let tmp_out_file_path = self
             .temp_folder
@@ -481,12 +470,12 @@ impl SophonPatcher {
         if !valid_file {
             (updater)(Update::FileHashCheckFailed(tmp_out_file_path.clone()));
 
-            let file_contents = std::fs::read(&tmp_out_file_path)?;
+            let file_hash = file_md5_hash_str(&tmp_out_file_path)?;
 
             return Err(SophonError::FileHashMismatch {
                 path: tmp_out_file_path,
                 expected: asset_info.AssetHashMd5.clone(),
-                got: md5_hash_str(&file_contents),
+                got: file_hash,
             });
         }
 
@@ -515,25 +504,19 @@ impl SophonPatcher {
     ) -> Result<(), SophonError> {
         let patch_chunk_path = self.download_patch_chunk(patch_chunk, progress, updater.clone())?;
 
-        let extracted_data = extract_patch_chunk_region(
-            &patch_chunk_path,
-            patch_chunk.PatchOffset,
-            patch_chunk.PatchLength,
-        )?;
-
         let tmp_file_path = self.temp_folder.join(format!("{}.tmp", expected_md5));
 
-        std::fs::write(&tmp_file_path, &extracted_data)?;
+        extract_patch_chunk_region_to_file(&patch_chunk_path, &tmp_file_path, patch_chunk)?;
 
         if !check_file(&tmp_file_path, expected_size, expected_md5)? {
             (updater)(Update::FileHashCheckFailed(tmp_file_path.clone()));
 
-            let file_contents = std::fs::read(&tmp_file_path)?;
+            let file_hash = file_md5_hash_str(&tmp_file_path)?;
 
             Err(SophonError::FileHashMismatch {
                 path: tmp_file_path,
                 expected: expected_md5.to_owned(),
-                got: md5_hash_str(&file_contents),
+                got: file_hash,
             })
         }
 
@@ -633,12 +616,22 @@ fn extract_patch_chunk_region(
     patch_chunk: impl AsRef<Path>,
     offset: u64,
     length: u64
-) -> std::io::Result<Vec<u8>> {
-    let mut buf = vec![0; length as usize];
+) -> std::io::Result<Take<File>> {
+    let mut file = File::open(patch_chunk)?;
+    file.seek(std::io::SeekFrom::Start(offset))?;
+    Ok(file.take(length))
+}
 
-    let file = File::open(patch_chunk)?;
+fn extract_patch_chunk_region_to_file(patch_chunk_file: impl AsRef<Path>, out_path: impl AsRef<Path>, patch_chunk: &SophonPatchAssetChunk) -> std::io::Result<()> {
+    let mut patch_data = extract_patch_chunk_region(
+        patch_chunk_file,
+        patch_chunk.PatchOffset,
+        patch_chunk.PatchLength,
+    )?;
 
-    file.read_exact_at(&mut buf, offset)?;
+    let mut patch_file = File::create(out_path)?;
 
-    Ok(buf)
+    std::io::copy(&mut patch_data, &mut patch_file)?;
+
+    Ok(())
 }


### PR DESCRIPTION
1. Fixed tracking of downloaded size
2. Added sub-directories in temp dir for temporary storage of downloaded chunks, files being processed and extracted patches, reducing clutter in the temp directory
3. Improved free space check to handle edge case where temp and output are the same dir
4. Removed a bunch of reading file contents to memory, instead using `std::io` traits implementations
5. The downloader now prefers to keep compressed chunks instead of decompressed ones