### PR TITLE
More sophon fixes

### DIFF
--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -242,6 +242,7 @@ impl VersionDiff {
     }
 
     fn download_game(&self, download_info: &SophonDownloadInfo, path: impl AsRef<Path>, updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::trace!("Downloading using {download_info:?} in {:?}", path.as_ref());
         let client = reqwest::blocking::Client::new();
         let installer = sophon::installer::SophonInstaller::new(download_info, client, self.temp_folder())?;
 
@@ -261,6 +262,7 @@ impl VersionDiff {
     }
 
     fn patch_game(&self, from: Version, diff: &SophonDiff, path: impl AsRef<Path>, updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::debug!("Patching from {from}, using diff {diff:?}, in {:?}", path.as_ref());
         let client = reqwest::blocking::Client::new();
         let patcher = sophon::updater::SophonPatcher::new(diff, client, self.temp_folder())?;
 
@@ -280,6 +282,7 @@ impl VersionDiff {
     }
 
     fn pre_download(&self, download_or_patch_info: &DownloadOrDiff, from: Version, updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::debug!("Predownloading from {from}, using diff {download_or_patch_info:?}");
         let client = reqwest::blocking::Client::new();
         match download_or_patch_info {
             DownloadOrDiff::Download(download_info) => {

--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -258,6 +258,10 @@ impl VersionDiff {
             std::fs::write(version_path, self.latest().version);
         }
 
+        tracing::warn!("Removing downloading cache from {:?}", installer.downloading_temp());
+
+        std::fs::remove_dir_all(installer.downloading_temp());
+
         Ok(())
     }
 
@@ -277,6 +281,10 @@ impl VersionDiff {
 
             std::fs::write(version_path, self.latest().version);
         }
+
+        tracing::warn!("Removing patching cache from {:?}", patcher.files_temp());
+
+        std::fs::remove_dir_all(patcher.files_temp());
 
         Ok(())
     }

--- a/src/games/genshin/voice_data/package.rs
+++ b/src/games/genshin/voice_data/package.rs
@@ -19,6 +19,7 @@ use crate::genshin::version_diff::*;
 /// Format: `(version, english, japanese, korean, chinese)`
 pub const VOICE_PACKAGES_SIZES: &[(&str, u64, u64, u64, u64)] = &[
     //         English(US)   Japanese      Korean        Chinese
+    ("5.6.0",  18981328917,  21627518083,  16446002370,  16665257451),
     ("5.5.0",  18412510172,  20933946124,  15886079840,  16128960332),
 
     // Size changed back and forth so I decided to comment old records.

--- a/src/sophon/installer.rs
+++ b/src/sophon/installer.rs
@@ -177,7 +177,7 @@ impl SophonInstaller {
 
     /// Folder to temporarily store files being downloaded
     #[inline(always)]
-    fn downloading_temp(&self) -> PathBuf {
+    pub fn downloading_temp(&self) -> PathBuf {
         self.temp_folder.join("downloading")
     }
 

--- a/src/sophon/updater.rs
+++ b/src/sophon/updater.rs
@@ -196,7 +196,7 @@ impl SophonPatcher {
 
     /// Folder to temporarily store files being updated (patched, created, etc)
     #[inline(always)]
-    fn files_temp(&self) -> PathBuf {
+    pub fn files_temp(&self) -> PathBuf {
         self.temp_folder.join("updating")
     }
 


### PR DESCRIPTION
feel free to delete any new `tracing::trace`s, used them to debug the IO errors in patching, which turned out to be missing write perms.

- Added 5.6.0 voiceover sizes, taken from the `getBuild` endpoint's `stats.uncompressed_size` field
- Remove download cache after installing patching
- Change patch chunks to be downloaded first and then applied later, rather than being downloaded on-demand.
- Changed Patcher's `Update` type to clearly message the three phases: deleting unused files, downloading patch chunks, and applying patches. This will need an update to the launcher.