### PR TITLE
feat: Sophon repairer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ brotli-decompressor = { version = "4.0", optional = true }
 
 # Needed for Sophon
 zstd = { version = "0.13", optional = true }
-reqwest = { version = "0.12", features = ["blocking", "json", "socks"], optional = true }
+reqwest = { version = "0.12", features = ["blocking", "h2", "http2", "json", "rustls-tls", "rustls-tls-webpki-roots", "socks"], default-features = false, optional = true }
 protobuf = { version = "3.7", optional = true }
 
 [features]

--- a/src/sophon/api_schemas/sophon_manifests.rs
+++ b/src/sophon/api_schemas/sophon_manifests.rs
@@ -44,6 +44,12 @@ pub struct DownloadInfo {
     pub url_suffix: String
 }
 
+impl DownloadInfo {
+    pub fn download_url(&self, id: &str) -> String {
+        format!("{}{}/{id}", self.url_prefix, self.url_suffix)
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManifestStats {
     pub compressed_size: String,

--- a/src/sophon/repairer.rs
+++ b/src/sophon/repairer.rs
@@ -1,0 +1,400 @@
+use std::{fs::{File, OpenOptions}, io::{Read, Seek, SeekFrom, Write}, os::unix::fs::FileExt, path::{Path, PathBuf}, sync::{atomic::AtomicU64, mpsc, Mutex}};
+
+use md5::{Digest, Md5};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+
+use super::{api_schemas::sophon_manifests::{DownloadInfo, SophonDownloadInfo}, bytes_check_md5, check_file, ensure_parent, file_md5_hash_str, file_region_hash_md5, installer::get_download_manifest, md5_hash_str, protos::SophonManifest::{SophonManifestAssetChunk, SophonManifestAssetProperty, SophonManifestProto}, SophonError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Update {
+    VerifyingStarted,
+
+    VerifyingProgress {
+        total: u64,
+        checked: u64,
+    },
+
+    VerifyingFinished {
+        broken: u64,
+    },
+
+    RepairingStarted,
+
+    RepairingProgress {
+        total: u64,
+        repaired: u64,
+    },
+
+    RepairingFinished,
+
+    DownloadingError(SophonError),
+
+    FileHashCheckFailed(PathBuf)
+}
+
+pub struct SophonRepairer {
+    pub client: Client,
+    pub manifests: Vec<(SophonDownloadInfo, SophonManifestProto)>,
+    pub temp_folder: PathBuf
+}
+
+impl SophonRepairer {
+    pub fn new(
+        download_infos: &[&SophonDownloadInfo],
+        client: Client,
+        temp_dir: impl AsRef<Path>
+    ) -> Result<Self, SophonError> {
+
+        let manifests = download_infos.iter().map(|di| {
+            get_download_manifest(client.clone(), di).map(|manifest| ((*di).clone(), manifest))
+        }).collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            client,
+            manifests,
+            temp_folder: temp_dir.as_ref().to_owned()
+        })
+    }
+
+    #[inline(always)]
+    pub fn with_temp_folder(mut self, temp_folder: PathBuf) -> Self {
+        self.temp_folder = temp_folder;
+
+        self
+    }
+
+    /// Folder to temporarily store files being downloaded
+    #[inline(always)]
+    pub fn downloading_temp(&self) -> PathBuf {
+        self.temp_folder.join("downloading")
+    }
+
+    /// Folder to temporarily store chunks
+    #[inline(always)]
+    fn chunk_temp_folder(&self) -> PathBuf {
+        self.downloading_temp().join("chunks")
+    }
+
+    /// Create all needed sub-directories in the temp folder
+    fn create_temp_dirs(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(self.downloading_temp())?;
+        std::fs::create_dir_all(self.chunk_temp_folder())?;
+
+        Ok(())
+    }
+
+    pub fn check_and_repair(&self, game_dir: impl AsRef<Path>, file_check_threads: usize, updater: impl Fn(Update) + Clone + Send + 'static) -> Result<(), SophonError> {
+        (updater)(Update::VerifyingStarted);
+
+        let broken = self.get_broken_files(&game_dir, file_check_threads, updater.clone())?;
+        let total_broken = broken.len() as u64;
+
+        (updater)(Update::VerifyingFinished { broken: total_broken });
+
+        (updater)(Update::RepairingStarted);
+
+        self.create_temp_dirs()?;
+
+        let mut repaired = 0;
+        (updater)(Update::RepairingProgress { total: total_broken, repaired });
+
+        for (download_info, asset_info) in broken {
+            let res = self.repair_file(&game_dir, download_info, asset_info);
+
+            match res {
+                Err(err) => {
+                    tracing::error!("Error repairing file `{}`: {err}", asset_info.AssetName);
+                    (updater)(Update::DownloadingError(err))
+                }
+                Ok(()) => {
+                    tracing::trace!("Repaired file `{}`", asset_info.AssetName);
+                    repaired += 1;
+                    (updater)(Update::RepairingProgress { total: total_broken, repaired })
+                }
+            }
+        }
+
+        (updater)(Update::RepairingFinished);
+
+        Ok(())
+    }
+
+    pub fn get_broken_files(&self, game_dir: impl AsRef<Path>, threads: usize, updater: impl Fn(Update) + Clone + Send + 'static) -> std::io::Result<Vec<(&DownloadInfo, &SophonManifestAssetProperty)>> {
+        let all_files = 
+            self
+            .manifests
+            .iter()
+            .flat_map(|(di, manifest)| manifest
+                .Assets
+                .iter()
+                .map(move |asset| (&di.chunk_download, asset))
+                )
+            .collect::<Vec<_>>();
+        let total = all_files.len() as u64;
+        (updater)(Update::VerifyingProgress { total, checked: 0 });
+        let files_to_check_pool = Mutex::new(all_files);
+        let pool = &files_to_check_pool;
+        let (sender, receiver) = mpsc::channel::<(&DownloadInfo, &SophonManifestAssetProperty)>();
+    
+        let verified_atomic = AtomicU64::new(0);
+        // scoped threads to allow borrowing some stuff from outer stuff
+        Ok(std::thread::scope(|scope| {
+                    let verified = &verified_atomic;
+                    for _ in 0..threads {
+                        let game_dir = game_dir.as_ref();
+                        let sender_clone = sender.clone();
+                        let updater_clone = updater.clone();
+                        scope.spawn(move || {
+                            'checkloop: loop {
+                                let (download_info, next_file) = {
+                                    let mut pool_lock = pool.lock().unwrap();
+                                    if let Some(next) = pool_lock.pop() {
+                                        next
+                                    } else {
+                                        break 'checkloop;
+                                    }
+                                };
+                                tracing::trace!("Checking `{}`", next_file.AssetName);
+                                match check_file(game_dir.join(&next_file.AssetName), next_file.AssetSize, &next_file.AssetHashMd5) {
+                                    Err(err) => {
+                                        tracing::error!("Failed to check file `{}`: {err}", next_file.AssetName)
+                                    },
+                                    Ok(false) => {
+                                        let _ = sender_clone.send((download_info, next_file));
+                                    },
+                                    Ok(true) => {
+                                        // Do nothing
+                                    }
+                                };
+                                tracing::trace!("Check `{}` completed", next_file.AssetName);
+                                (updater_clone)(Update::VerifyingProgress { total, checked: verified.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1 });
+                            }
+                        });
+                    }
+                    drop(sender);
+                    receiver.into_iter().collect()
+                }))
+    }
+
+    pub fn repair_file(&self, game_dir: impl AsRef<Path>, download_info: &DownloadInfo, asset_info: &SophonManifestAssetProperty) -> Result<(), SophonError> {
+        let target_file = game_dir.as_ref().join(&asset_info.AssetName);
+
+        if !target_file.exists() {
+            self.download_chunked_file(&game_dir, download_info, asset_info)
+        } else {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .read(true)
+                .open(&target_file)?;
+            file.set_len(asset_info.AssetSize)?;
+
+            for chunk in &asset_info.AssetChunks {
+                if chunk.ChunkDecompressedHashMd5 != file_region_hash_md5(&mut file, chunk.ChunkOnFileOffset, chunk.ChunkSizeDecompressed)? {
+                    let mut chunk_file = self.download_chunk_uncompressed(download_info, chunk)?;
+                    file.seek(SeekFrom::Start(chunk.ChunkOnFileOffset))?;
+                    std::io::copy(&mut chunk_file, &mut file)?;
+                }
+            }
+
+            drop(file);
+
+            if !check_file(&target_file, asset_info.AssetSize, &asset_info.AssetHashMd5)? {
+                Err(SophonError::FileHashMismatch {
+                    got: file_md5_hash_str(&target_file)?,
+                    path: target_file,
+                    expected: asset_info.AssetHashMd5.clone(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn download_chunked_file(
+        &self,
+        output_folder: impl AsRef<Path>,
+        download_info: &DownloadInfo,
+        file_info: &SophonManifestAssetProperty,
+    ) -> Result<(), SophonError> {
+        let out_file_path = output_folder.as_ref().join(&file_info.AssetName);
+
+        // check if file exists and hash matches to skip download
+        if check_file(&out_file_path, file_info.AssetSize, &file_info.AssetHashMd5)? {
+            return Ok(());
+        }
+
+        let temp_file_path = self.downloading_temp().join(format!("{}.temp", file_info.AssetHashMd5));
+
+        let file = File::create(&temp_file_path).unwrap();
+
+        file.set_len(file_info.AssetSize).unwrap();
+
+        for chunk_info in &file_info.AssetChunks {
+            let mut chunk_file = self.download_chunk_uncompressed(download_info, chunk_info)?;
+
+            let mut buf = Vec::with_capacity(chunk_info.ChunkSizeDecompressed as usize);
+
+            chunk_file.read_to_end(&mut buf)?;
+
+            // Drop chunk file handle early, not needed anymore
+            // Also just in case it would prevent deletion (if needed)
+            drop(chunk_file);
+
+            file.write_all_at(&buf, chunk_info.ChunkOnFileOffset)?;
+
+            // Chunks downloaded with compression, and the compressed version si likely cached on
+            // disk. An uncompressed version just been used, remove it to not duplicate.
+            // If the chunk was downlaoded uncompressed - don't remove it
+            if download_info.compression == 1 {
+                let uncompressed_chunk_path = self.chunk_temp_folder().join(format!("{}.chunk", chunk_info.ChunkName));
+
+                std::fs::remove_file(&uncompressed_chunk_path)?;
+            }
+        }
+
+        drop(file);
+
+        if check_file(&temp_file_path, file_info.AssetSize, &file_info.AssetHashMd5)? {
+            ensure_parent(&out_file_path).map_err(|e| SophonError::TempFileError {
+                path: temp_file_path.clone(),
+                message: e.to_string()
+            })?;
+
+            std::fs::copy(&temp_file_path, &out_file_path).map_err(|e| {
+                SophonError::OutputFileError {
+                    path: temp_file_path.clone(),
+                    message: e.to_string()
+                }
+            })?;
+
+            std::fs::remove_file(&temp_file_path).map_err(|e| SophonError::OutputFileError {
+                path: temp_file_path.clone(),
+                message: e.to_string()
+            })?;
+
+            Ok(())
+        }
+
+        else {
+            Err(SophonError::FileHashMismatch {
+                got: file_md5_hash_str(&temp_file_path)?,
+                path: temp_file_path,
+                expected: file_info.AssetHashMd5.clone(),
+            })
+        }
+    }
+
+    /// Download the chunk is the raw-est state and save to the temp folder, returning the
+    /// path is is saved at. If the chunk is compressed, it is saved as `ChunkName.chunk.zstd`,
+    /// otehrwise it's saved without `.zstd` file extension.
+    /// If the chunk file already exists, checks it and returns the path to it if length and hash
+    /// match.
+    fn download_chunk_raw(
+        &self,
+        download_info: &DownloadInfo,
+        chunk_info: &SophonManifestAssetChunk,
+    ) -> Result<PathBuf, SophonError> {
+        let (chunk_file_name, chunk_size, chunk_hash) = if download_info.compression == 1 {
+            (
+                format!("{}.chunk.zstd", chunk_info.ChunkName),
+                chunk_info.ChunkSize,
+                &chunk_info.ChunkCompressedHashMd5
+            )
+        } else {
+            (
+                format!("{}.chunk", chunk_info.ChunkName),
+                chunk_info.ChunkSizeDecompressed,
+                &chunk_info.ChunkDecompressedHashMd5
+            )
+        };
+
+        let chunk_path = self.chunk_temp_folder().join(&chunk_file_name);
+
+        if check_file(&chunk_path, chunk_size, chunk_hash)? {
+            Ok(chunk_path)
+        }
+
+        else {
+            let chunk_url = download_info.download_url(&chunk_info.ChunkName);
+
+            let response = self.client.get(&chunk_url)
+                .send()?
+                .error_for_status()?;
+
+            let chunk_bytes = response.bytes()?;
+
+            if chunk_bytes.len() as u64 == chunk_size && bytes_check_md5(&chunk_bytes, chunk_hash) {
+                std::fs::write(&chunk_path, &chunk_bytes)?;
+
+                Ok(chunk_path)
+            }
+
+            else {
+                Err(SophonError::ChunkHashMismatch {
+                    expected: chunk_hash.to_string(),
+                    got: md5_hash_str(&chunk_bytes)
+                })
+            }
+        }
+    }
+
+    /// Download the chunk and if it is compressed, decompress it. If a compressed chunk is
+    /// downloaded already, it checks that file and uses it to produce a decompressed chunk.
+    /// If a decompressed chunk already exists, checks it and returns its File without
+    /// redownloading on successfull check.
+    fn download_chunk_uncompressed(
+        &self,
+        download_info: &DownloadInfo,
+        chunk_info: &SophonManifestAssetChunk,
+    ) -> Result<File, SophonError> {
+        let uncompressed_chunk_path = self.chunk_temp_folder().join(format!("{}.chunk", chunk_info.ChunkName));
+
+        let uncompressed_size = chunk_info.ChunkSizeDecompressed;
+        let uncompressed_hash = &chunk_info.ChunkDecompressedHashMd5;
+
+        if std::fs::exists(&uncompressed_chunk_path)? && check_file(&uncompressed_chunk_path, uncompressed_size, uncompressed_hash)? {
+            File::open(&uncompressed_chunk_path).map_err(Into::into)
+        }
+
+        else {
+            let raw_chunk_path = self.download_chunk_raw(download_info, chunk_info)?;
+
+            if download_info.compression == 1 {
+                // File is compressed, decompress it
+                let file_contents = std::fs::read(&raw_chunk_path)?;
+                let decompressed_bytes = zstd::decode_all(&*file_contents)?;
+
+                if decompressed_bytes.len() as u64 == uncompressed_size && bytes_check_md5(&decompressed_bytes, uncompressed_hash) {
+                    // Use OpenOptions so that the file doesn't need to be reopened because of
+                    // missing `read` option when using `File::create`
+                    let mut file = OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .read(true)
+                        .open(&uncompressed_chunk_path)?;
+
+                    file.write_all(&decompressed_bytes)?;
+
+                    // Rewind the cursor
+                    file.seek(SeekFrom::Start(0))?;
+
+                    Ok(file)
+                }
+
+                else {
+                    Err(SophonError::ChunkHashMismatch {
+                        expected: uncompressed_hash.to_string(),
+                        got: md5_hash_str(&decompressed_bytes)
+                    })
+                }
+            }
+
+            else {
+                // File already downloaded uncompressed
+                File::open(&raw_chunk_path).map_err(Into::into)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fetches manifest for the latest version and uses it to check every file. If the file doesn't pass the check, checks every segment of it corresponding to a chunk and replaces data by downloading the chunk. If the file doesn't exist, just downloads it. The general file integrity is multithreaded (to kinda mirror the launcher's built-in repairer) but repair process is still single-threaded.

In addition to that:
- Tweaked reqwest features to use rustls with webpki roots (removes openssl dependency)
- In one place replaced reading a file into memory for hashing with a call to the helper function that uses `std::io::copy` instead

Launcher side of the repairer is at https://github.com/JohnTheCoolingFan/an-anime-game-launcher/tree/sophon-repair (not a PR yet, probably will submit after I make the sophon stuff multithreaded)