### PR TITLE
Fix preload progress

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -17,3 +17,4 @@ single_line_let_else_max_width = 0
 struct_lit_single_line = false
 trailing_comma = "Never"
 use_field_init_shorthand = true
+control_brace_style = "ClosingNextLine"

--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -398,6 +398,35 @@ impl VersionDiff {
 
         Ok(())
     }
+
+    /// Get the matching field value for this diff. Returns none in case of
+    /// [`VersionDiff::Latest`] or [`VersionDiff::Outdated`]
+    pub fn matching_field(&self) -> Option<&str> {
+        match self {
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
+            Self::Predownload {
+                download_info, ..
+            } => match download_info {
+                DownloadOrDiff::Patch(SophonDiff {
+                    matching_field, ..
+                })
+                | DownloadOrDiff::Download(SophonDownloadInfo {
+                    matching_field, ..
+                }) => Some(matching_field)
+            },
+            Self::Diff {
+                diff, ..
+            } => Some(&diff.matching_field),
+            Self::NotInstalled {
+                download_info, ..
+            } => Some(&download_info.matching_field)
+        }
+    }
 }
 
 impl VersionDiffExt for VersionDiff {

--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -1,24 +1,19 @@
 use std::path::{Path, PathBuf};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::version::Version;
 use crate::sophon::SophonError;
-use crate::sophon::api_schemas::{
-    sophon_diff::SophonDiff,
-    sophon_manifests::SophonDownloadInfo,
-    DownloadOrDiff
-};
+use crate::sophon::api_schemas::DownloadOrDiff;
+use crate::sophon::api_schemas::sophon_diff::SophonDiff;
+use crate::sophon::api_schemas::sophon_manifests::SophonDownloadInfo;
 use crate::sophon::installer::SophonInstaller;
 use crate::sophon::updater::SophonPatcher;
 use crate::sophon;
-
 use crate::traits::version_diff::VersionDiffExt;
-
 #[cfg(feature = "install")]
 use crate::installer::installer::Update as InstallerUpdate;
-
 use super::consts::GameEdition;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,9 +113,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
         ///
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -141,9 +138,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
         ///
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -170,9 +169,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
         ///
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -188,13 +189,23 @@ impl VersionDiff {
     pub fn version_file_path(&self) -> Option<PathBuf> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { version_file_path, .. } |
-            Self::Diff { version_file_path, .. } |
-            Self::NotInstalled { version_file_path, .. } => version_file_path.to_owned()
+            Self::Predownload {
+                version_file_path, ..
+            }
+            | Self::Diff {
+                version_file_path, ..
+            }
+            | Self::NotInstalled {
+                version_file_path, ..
+            } => version_file_path.to_owned()
         }
     }
 
@@ -204,13 +215,23 @@ impl VersionDiff {
     pub fn temp_folder(&self) -> PathBuf {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => std::env::temp_dir(),
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => std::env::temp_dir(),
 
             // Can be installed
-            Self::Predownload { temp_folder, .. } |
-            Self::Diff { temp_folder, .. } |
-            Self::NotInstalled { temp_folder, .. } => match temp_folder {
+            Self::Predownload {
+                temp_folder, ..
+            }
+            | Self::Diff {
+                temp_folder, ..
+            }
+            | Self::NotInstalled {
+                temp_folder, ..
+            } => match temp_folder {
                 Some(path) => path.to_owned(),
                 None => std::env::temp_dir()
             }
@@ -220,23 +241,33 @@ impl VersionDiff {
     pub fn with_temp_folder(mut self, temp: PathBuf) -> Self {
         match &mut self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => self,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => self,
 
             // Can be installed
-            Self::Predownload { temp_folder, .. } => {
+            Self::Predownload {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
             }
 
-            Self::Diff { temp_folder, .. } => {
+            Self::Diff {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
             }
 
-            Self::NotInstalled { temp_folder, .. } => {
+            Self::NotInstalled {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
@@ -259,11 +290,7 @@ impl VersionDiff {
 
         let client = reqwest::blocking::Client::new();
 
-        let installer = SophonInstaller::new(
-            client,
-            download_info,
-            self.temp_folder()
-        )?;
+        let installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
 
         installer.install(path.as_ref(), thread_count, move |msg| {
             (updater)(msg.into());
@@ -272,8 +299,10 @@ impl VersionDiff {
         // Create `.version` file here even if hdiff patching is failed because
         // it's easier to explain user why he should run files repairer than
         // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)] {
-            let version_path = self.version_file_path()
+        #[allow(unused_must_use)]
+        {
+            let version_path = self
+                .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
             std::fs::write(version_path, self.latest().version);
@@ -308,15 +337,17 @@ impl VersionDiff {
 
         let patcher = SophonPatcher::new(client, diff, self.temp_folder())?;
 
-        patcher.update(&path, from, thread_count, move |msg | {
+        patcher.update(&path, from, thread_count, move |msg| {
             (updater)(msg.into());
         })?;
 
         // Create `.version` file here even if hdiff patching is failed because
         // it's easier to explain user why he should run files repairer than
         // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)] {
-            let version_path = self.version_file_path()
+        #[allow(unused_must_use)]
+        {
+            let version_path = self
+                .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
             std::fs::write(version_path, self.latest().version);
@@ -351,9 +382,7 @@ impl VersionDiff {
             DownloadOrDiff::Download(download_info) => {
                 let installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
 
-                installer.pre_download(
-                    thread_count,
-                    move |msg| {
+                installer.pre_download(thread_count, move |msg| {
                     (updater)(msg.into());
                 })?;
             }
@@ -372,84 +401,145 @@ impl VersionDiff {
 }
 
 impl VersionDiffExt for VersionDiff {
+    type Edition = GameEdition;
     type Error = DiffDownloadingError;
     type Update = DiffUpdate;
-    type Edition = GameEdition;
 
     fn edition(&self) -> GameEdition {
         match self {
-            Self::Latest { edition, .. } |
-            Self::Predownload { edition, .. } |
-            Self::Diff { edition, .. } |
-            Self::Outdated { edition, .. } |
-            Self::NotInstalled { edition, .. } => *edition
+            Self::Latest {
+                edition, ..
+            }
+            | Self::Predownload {
+                edition, ..
+            }
+            | Self::Diff {
+                edition, ..
+            }
+            | Self::Outdated {
+                edition, ..
+            }
+            | Self::NotInstalled {
+                edition, ..
+            } => *edition
         }
     }
 
     fn current(&self) -> Option<Version> {
         match self {
-            Self::Latest { version: current, .. } |
-            Self::Predownload { current, .. } |
-            Self::Diff { current, .. } |
-            Self::Outdated { current, .. } => Some(*current),
+            Self::Latest {
+                version: current, ..
+            }
+            | Self::Predownload {
+                current, ..
+            }
+            | Self::Diff {
+                current, ..
+            }
+            | Self::Outdated {
+                current, ..
+            } => Some(*current),
 
-            Self::NotInstalled { .. } => None
+            Self::NotInstalled {
+                ..
+            } => None
         }
     }
 
     fn latest(&self) -> Version {
         match self {
-            Self::Latest { version: latest, .. } |
-            Self::Predownload { latest, .. } |
-            Self::Diff { latest, .. } |
-            Self::Outdated { latest, .. } |
-            Self::NotInstalled { latest, .. } => *latest
+            Self::Latest {
+                version: latest, ..
+            }
+            | Self::Predownload {
+                latest, ..
+            }
+            | Self::Diff {
+                latest, ..
+            }
+            | Self::Outdated {
+                latest, ..
+            }
+            | Self::NotInstalled {
+                latest, ..
+            } => *latest
         }
     }
 
     fn downloaded_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { downloaded_size, .. } |
-            Self::Diff { downloaded_size, .. } |
-            Self::NotInstalled { downloaded_size, .. } => Some(*downloaded_size)
+            Self::Predownload {
+                downloaded_size, ..
+            }
+            | Self::Diff {
+                downloaded_size, ..
+            }
+            | Self::NotInstalled {
+                downloaded_size, ..
+            } => Some(*downloaded_size)
         }
     }
 
     fn unpacked_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { unpacked_size, .. } |
-            Self::Diff { unpacked_size, .. } |
-            Self::NotInstalled { unpacked_size, .. } => Some(*unpacked_size)
+            Self::Predownload {
+                unpacked_size, ..
+            }
+            | Self::Diff {
+                unpacked_size, ..
+            }
+            | Self::NotInstalled {
+                unpacked_size, ..
+            } => Some(*unpacked_size)
         }
     }
 
     fn installation_path(&self) -> Option<&Path> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { installation_path, .. } |
-            Self::Diff { installation_path, .. } |
-            Self::NotInstalled { installation_path, .. } => match installation_path {
+            Self::Predownload {
+                installation_path, ..
+            }
+            | Self::Diff {
+                installation_path, ..
+            }
+            | Self::NotInstalled {
+                installation_path, ..
+            } => match installation_path {
                 Some(path) => Some(path.as_path()),
                 None => None
             }
         }
     }
 
-    // There isn't a single type providing download information, so this method is useless
+    // There isn't a single type providing download information, so this method is
+    // useless
     fn downloading_uri(&self) -> Option<String> {
         None
     }
@@ -464,15 +554,19 @@ impl VersionDiffExt for VersionDiff {
 
         match self {
             // Can't be downloaded
-            Self::Latest { .. } => Err(Self::Error::AlreadyLatest),
-            Self::Outdated { .. } => Err(Self::Error::Outdated),
+            Self::Latest {
+                ..
+            } => Err(Self::Error::AlreadyLatest),
+            Self::Outdated {
+                ..
+            } => Err(Self::Error::Outdated),
 
             // Can be downloaded
-            //Self::Predownload { uri, .. } |
-            //Self::Diff { uri, .. } => uri,
+            // Self::Predownload { uri, .. } |
+            // Self::Diff { uri, .. } => uri,
 
             // Can be installed but amogus
-            //Self::NotInstalled { .. } => return Err(Self::Error::MultipleSegments),
+            // Self::NotInstalled { .. } => return Err(Self::Error::MultipleSegments),
             _ => Err(Self::Error::MultipleSegments)
         }
     }
@@ -498,21 +592,30 @@ impl VersionDiffExt for VersionDiff {
                 }
             });
 
-            self.install_to(folder, 1, move |msg| {
-                match msg {
-                    DiffUpdate::SophonPatcherUpdate(sophon::updater::Update::DownloadingProgressBytes { downloaded_bytes, total_bytes }) => {
-                        let _ = sender.send((downloaded_bytes, total_bytes));
+            self.install_to(folder, 1, move |msg| match msg {
+                DiffUpdate::SophonPatcherUpdate(
+                    sophon::updater::Update::DownloadingProgressBytes {
+                        downloaded_bytes,
+                        total_bytes
                     }
-
-                    DiffUpdate::SophonInstallerUpdate(sophon::installer::Update::DownloadingProgressBytes { downloaded_bytes, total_bytes }) => {
-                        let _ = sender.send((downloaded_bytes, total_bytes));
-                    }
-
-                    _ => ()
+                ) => {
+                    let _ = sender.send((downloaded_bytes, total_bytes));
                 }
+
+                DiffUpdate::SophonInstallerUpdate(
+                    sophon::installer::Update::DownloadingProgressBytes {
+                        downloaded_bytes,
+                        total_bytes
+                    }
+                ) => {
+                    let _ = sender.send((downloaded_bytes, total_bytes));
+                }
+
+                _ => ()
             })?;
 
-            proxy_thread_handle.join()
+            proxy_thread_handle
+                .join()
                 .expect("failed to join game downloader thread");
         }
 
@@ -529,15 +632,29 @@ impl VersionDiffExt for VersionDiff {
 
         match self {
             // Can't be installed
-            Self::Latest { .. } => Err(Self::Error::AlreadyLatest),
-            Self::Outdated { .. } => Err(Self::Error::Outdated),
+            Self::Latest {
+                ..
+            } => Err(Self::Error::AlreadyLatest),
+            Self::Outdated {
+                ..
+            } => Err(Self::Error::Outdated),
 
             // Can be installed
-            Self::Diff { diff, current, .. } => self.patch_game(*current, thread_count, diff, path, updater),
-            Self::NotInstalled { download_info, .. } => self.download_game(download_info, thread_count, path, updater),
+            Self::Diff {
+                diff,
+                current,
+                ..
+            } => self.patch_game(*current, thread_count, diff, path, updater),
+            Self::NotInstalled {
+                download_info, ..
+            } => self.download_game(download_info, thread_count, path, updater),
 
             // Predownload without applying
-            Self::Predownload { download_info, current , ..} => self.pre_download(download_info, *current, thread_count, updater)
+            Self::Predownload {
+                download_info,
+                current,
+                ..
+            } => self.pre_download(download_info, *current, thread_count, updater)
         }
     }
 }

--- a/src/sophon/api_schemas/sophon_diff.rs
+++ b/src/sophon/api_schemas/sophon_diff.rs
@@ -13,7 +13,8 @@ pub struct SophonDiffs {
 }
 
 impl SophonDiffs {
-    /// `matching_field` is usually either `game` or one of the voiceover language options
+    /// `matching_field` is usually either `game` or one of the voiceover
+    /// language options
     pub fn get_manifests_for(&self, matching_field: &str) -> Option<&SophonDiff> {
         self.manifests
             .iter()

--- a/src/sophon/api_schemas/sophon_manifests.rs
+++ b/src/sophon/api_schemas/sophon_manifests.rs
@@ -8,7 +8,8 @@ pub struct SophonDownloads {
 }
 
 impl SophonDownloads {
-    /// `matching_field` is usually either `game` or one of the voiceover language options
+    /// `matching_field` is usually either `game` or one of the voiceover
+    /// language options
     pub fn get_manifests_for(&self, matching_field: &str) -> Option<&SophonDownloadInfo> {
         self.manifests
             .iter()

--- a/src/sophon/installer.rs
+++ b/src/sophon/installer.rs
@@ -15,9 +15,9 @@ use super::protos::SophonManifest::{
     SophonManifestAssetChunk, SophonManifestAssetProperty, SophonManifestProto
 };
 use super::{
+    ArtifactDownloadState, DownloadQueue, GameEdition, SophonError, ThreadQueue,
     add_user_write_permission_to_file, api_get_request, check_file, ensure_parent,
-    file_md5_hash_str, get_protobuf_from_url, ArtifactDownloadState, DownloadQueue, GameEdition,
-    SophonError, ThreadQueue
+    file_md5_hash_str, get_protobuf_from_url
 };
 use crate::prelude::{free_space, prettify_bytes};
 use crate::sophon::md5_hash_str;
@@ -93,7 +93,8 @@ impl ChunkInfo<'_> {
             .download_url(&self.chunk_manifest.ChunkName)
     }
 
-    /// returns the expected size and md5 hash that will be used to download and check this chunk
+    /// returns the expected size and md5 hash that will be used to download and
+    /// check this chunk
     #[inline(always)]
     fn chunk_file_info(&self) -> (u64, &str) {
         if self.is_compressed() {
@@ -198,13 +199,10 @@ impl<'a> DownloadIndex<'a> {
                 chunk_files_list.0.push(&file_manifest.AssetName);
             }
 
-            files.insert(
-                &file_manifest.AssetName,
-                FileInfo {
-                    file_manifest,
-                    download_info: &download_info.chunk_download
-                }
-            );
+            files.insert(&file_manifest.AssetName, FileInfo {
+                file_manifest,
+                download_info: &download_info.chunk_download
+            });
         }
 
         Self {
@@ -258,9 +256,9 @@ impl<'a> DownloadIndex<'a> {
             .fetch_add(amount, std::sync::atomic::Ordering::SeqCst);
     }
 
-    /// Process chunk download failure. Either pushes the chunk onto the retries queue or sends the
-    /// chunk download fail update message using the updater. Refer to [Self::count_chunk_fail] for
-    /// more info.
+    /// Process chunk download failure. Either pushes the chunk onto the retries
+    /// queue or sends the chunk download fail update message using the
+    /// updater. Refer to [Self::count_chunk_fail] for more info.
     fn process_download_fail<'b>(
         &self,
         chunk: ChunkInfo<'a>,
@@ -273,11 +271,12 @@ impl<'a> DownloadIndex<'a> {
         }
     }
 
-    /// A download attempt or check failed, decrement the retry count or report the chunk as
-    /// completely failed.
-    /// The error type is a message to emit in case of a completely faield chunk download.
-    /// If this returns Ok, push the chunk on the retries queue.
-    /// If this returns Err, emit the fail message for this chunk and stop retrying.
+    /// A download attempt or check failed, decrement the retry count or report
+    /// the chunk as completely failed.
+    /// The error type is a message to emit in case of a completely faield chunk
+    /// download. If this returns Ok, push the chunk on the retries queue.
+    /// If this returns Err, emit the fail message for this chunk and stop
+    /// retrying.
     fn count_download_fail(&self, artifact_name: &'a String) -> Result<(), Update> {
         let mut states_lock = self
             .download_states
@@ -317,8 +316,8 @@ impl<'a> DownloadIndex<'a> {
     }
 
     /// Returns true to continue downloading, false to exit the loop.
-    /// if anything is still downloading, uses the [`Condvar`] to wait until the states are updated
-    /// by patching/checking threads and checks again.
+    /// if anything is still downloading, uses the [`Condvar`] to wait until the
+    /// states are updated by patching/checking threads and checks again.
     fn wait_downloading(&self) -> bool {
         let mut guard = self
             .download_states
@@ -326,8 +325,9 @@ impl<'a> DownloadIndex<'a> {
             .expect("Something poisoned the mutex");
         if Self::any_downloading(&guard) {
             // This message is printed way too often
-            //tracing::debug!("Some artifacts still being downloaded or checked, waiting for updates");
-            // unlocks the mutex during wait, see [`Condvar::wait`]
+            // tracing::debug!("Some artifacts still being downloaded or checked, waiting
+            // for updates"); unlocks the mutex during wait, see
+            // [`Condvar::wait`]
             guard = self
                 .download_states_notifier
                 .wait(guard)
@@ -452,7 +452,7 @@ impl SophonInstaller {
             let updater_clone = updater.clone();
             let mut chunk_dedupe_set = HashSet::with_capacity(download_index.chunks_used_in.len());
             let download_queue = DownloadChunkQueue {
-                //tasks_iter: download_index.chunks.values().peekable(),
+                // tasks_iter: download_index.chunks.values().peekable(),
                 tasks_iter: download_index
                     .files
                     .values()
@@ -550,10 +550,12 @@ impl SophonInstaller {
         (updater)(Update::DownloadingFinished);
     }
 
-    /// Loops over the tasks and retries and tries to download them, pushing onto the file assembly queue
-    /// if all the chunks for a file succeeded. If both the tasks iterator and the retries queue don't return
-    /// anything, checks if they are empty and then checks if there are any unfinished chunks and waits
-    /// for either all chunks to finish applying or a new retry being pushed onto the queue.
+    /// Loops over the tasks and retries and tries to download them, pushing
+    /// onto the file assembly queue if all the chunks for a file succeeded.
+    /// If both the tasks iterator and the retries queue don't return
+    /// anything, checks if they are empty and then checks if there are any
+    /// unfinished chunks and waits for either all chunks to finish applying
+    /// or a new retry being pushed onto the queue.
     fn artifact_download_loop<'a, 'b, I: Iterator<Item = ChunkInfo<'a>> + 'b>(
         &self,
         mut task_queue: DownloadChunkQueue<'a, 'b, I>,
@@ -564,7 +566,8 @@ impl SophonInstaller {
         let mut files_dispatched = HashSet::new();
         loop {
             if let Some(task) = task_queue.next() {
-                // Check if the file already exists on disk and if it does, skip re-downloading it
+                // Check if the file already exists on disk and if it does, skip re-downloading
+                // it
                 let artifact_path = self.tmp_artifact_file_path(&task);
 
                 let res = if artifact_path.exists() {
@@ -639,7 +642,8 @@ impl SophonInstaller {
         download_index.download_states_notifier.notify_all();
     }
 
-    // instrumenting to maybe try and see how much time it takes to download and save
+    // instrumenting to maybe try and see how much time it takes to download and
+    // save
     #[tracing::instrument(level = "trace", err, skip_all, fields(chunk = task.chunk_manifest.ChunkName, download_size = task.chunk_file_info().0))]
     fn download_artifact(&self, task: &ChunkInfo) -> Result<(), SophonError> {
         let download_url = task.download_url();

--- a/src/sophon/installer.rs
+++ b/src/sophon/installer.rs
@@ -509,6 +509,9 @@ impl SophonInstaller {
 
         self.predownload_multithreaded(thread_count, updater);
 
+        let marker_file_path = self.downloading_temp().join(".predownloadcomplete");
+        File::create(marker_file_path)?;
+
         Ok(())
     }
 
@@ -896,7 +899,8 @@ impl SophonInstaller {
     /// Folder to temporarily store files being downloaded
     #[inline]
     pub fn downloading_temp(&self) -> PathBuf {
-        self.temp_folder.join("downloading")
+        self.temp_folder
+            .join(format!("downloading-{}", self.download_info.matching_field))
     }
 
     fn tmp_downloading_file_path(&self, file_info: &FileInfo) -> PathBuf {

--- a/src/sophon/mod.rs
+++ b/src/sophon/mod.rs
@@ -64,7 +64,9 @@ impl GameEdition {
     pub fn branches_host(&self) -> &str {
         match self {
             Self::Global => {
-                concat!("https://", "s", "g-hy", "p-api.", "h", "oy", "over", "se", ".com")
+                concat!(
+                    "https://", "s", "g-hy", "p-api.", "h", "oy", "over", "se", ".com"
+                )
             }
             Self::China => concat!("https://", "hy", "p-api.", "mi", "h", "oyo", ".com")
         }
@@ -287,8 +289,8 @@ fn file_region_hash_md5(file: &mut File, offset: u64, length: u64) -> std::io::R
 
 // TODO:
 // - Cull some variants of SophonError, especially those that are unused
-// - Make some better variants describign where the error happened, perhaps steal anyhow's context
-//   idea but simpler, especially useful for I/O errors.
+// - Make some better variants describign where the error happened, perhaps
+//   steal anyhow's context idea but simpler, especially useful for I/O errors.
 // - Cull unused installer/update messages
 
 #[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
1. Fixed preload progress display to not be stuck at 0
2. Fixed deadlock that occurs sometimes related to waiting for updates in the chunk states
3. Moved update/install temp to `{updating,downloading}-${MATCHING_FIELD}`, which means voice pack temps downloaded during preload won't be removed after installing the main game update
4. Added `.predownloadcomplete` file in the temporary subdirectory of installer/updater to indicate when a preload of a game component has been completed.