### PR TITLE
Fix api schema and use

### DIFF
--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -2,13 +2,12 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use crate::{sophon, version::Version};
+use crate::sophon;
+use crate::version::Version;
 use crate::traits::prelude::*;
-
 use super::api;
 use super::consts::*;
 use super::version_diff::*;
-
 use super::voice_data::locale::VoiceLocale;
 use super::voice_data::package::VoicePackage;
 
@@ -41,7 +40,8 @@ impl GameExt for Game {
 
     #[inline]
     fn is_installed(&self) -> bool {
-        self.path.join(self.edition.data_folder())
+        self.path
+            .join(self.edition.data_folder())
             .join("globalgamemanagers")
             .exists()
     }
@@ -53,11 +53,9 @@ impl GameExt for Game {
 
         let version = api::request(edition)?.main.major.version;
 
-        Version::from_str(&version)
-            .ok_or_else(|| {
-                anyhow::anyhow!("api returned invalid game version format")
-                    .context(version)
-            })
+        Version::from_str(&version).ok_or_else(|| {
+            anyhow::anyhow!("api returned invalid game version format").context(version)
+        })
     }
 
     #[tracing::instrument(level = "debug", ret)]
@@ -73,7 +71,9 @@ impl GameExt for Game {
             .map(|version| Version::new(version[0], version[1], version[2]))
             .ok();
 
-        let path = self.path.join(self.edition.data_folder())
+        let path = self
+            .path
+            .join(self.edition.data_folder())
             .join("globalgamemanagers");
 
         let file = File::open(path)?;
@@ -99,7 +99,11 @@ impl GameExt for Game {
                 }
 
                 95 => {
-                    if correct && !version[0].is_empty() && !version[1].is_empty() && !version[2].is_empty() {
+                    if correct
+                        && !version[0].is_empty()
+                        && !version[1].is_empty()
+                        && !version[2].is_empty()
+                    {
                         let found_version = Version::new(
                             bytes_to_num(&version[0]),
                             bytes_to_num(&version[1]),
@@ -125,7 +129,6 @@ impl GameExt for Game {
                     if correct && b"0123456789".contains(&byte) {
                         version[version_ptr].push(byte);
                     }
-
                     else {
                         correct = false;
                     }
@@ -148,7 +151,8 @@ impl Game {
     pub fn get_voice_packages(&self) -> anyhow::Result<Vec<VoicePackage>> {
         let content = std::fs::read_dir(get_voice_packages_path(&self.path, self.edition))?;
 
-        let packages = content.into_iter()
+        let packages = content
+            .into_iter()
             .flatten()
             .flat_map(|entry| {
                 VoiceLocale::from_str(entry.file_name().to_string_lossy())
@@ -171,20 +175,20 @@ impl Game {
 
         let game_branches = sophon::get_game_branches_info(&client, game_edition.into())?;
 
-        let latest_version = game_branches.latest_version_by_id(self.edition.game_id())
+        let latest_version = game_branches
+            .latest_version_by_id(self.edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to find the latest game version")
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let branch_info = game_branches.get_game_by_id(
-            self.edition.game_id(),
-            latest_version
-        ).ok_or_else(|| {
-            anyhow::anyhow!("failed to get the game version information")
-                .context(format!("game id: {}", game_edition.game_id()))
-                .context(format!("game version: {latest_version}"))
-        })?;
+        let branch_info = game_branches
+            .get_game_by_id(self.edition.game_id(), latest_version)
+            .ok_or_else(|| {
+                anyhow::anyhow!("failed to get the game version information")
+                    .context(format!("game id: {}", game_edition.game_id()))
+                    .context(format!("game version: {latest_version}"))
+            })?;
 
         if self.is_installed() {
             let current = match self.get_version() {
@@ -198,7 +202,8 @@ impl Game {
                             game_edition.into()
                         )?;
 
-                        let download_info = game_downloads.get_manifests_for("game")
+                        let download_info = game_downloads
+                            .get_manifests_for("game")
                             .cloned()
                             .ok_or_else(|| anyhow::anyhow!("failed to get game manifest"))?;
 
@@ -233,7 +238,11 @@ impl Game {
                 // (which is not possible in reality) we should just say thath the game
                 // is latest
                 if let Some(predownload_info) = &branch_info.pre_download {
-                    if predownload_info.diff_tags.iter().any(|pre_diff| *pre_diff == current) {
+                    if predownload_info
+                        .diff_tags
+                        .iter()
+                        .any(|pre_diff| *pre_diff == current)
+                    {
                         let diffs = sophon::updater::get_game_diffs_sophon_info(
                             &client,
                             predownload_info,
@@ -246,11 +255,21 @@ impl Game {
                             current,
                             latest: Version::from_str(&predownload_info.tag).unwrap(),
 
-                            downloaded_size: diff_info.stats.get(&current.to_string()).unwrap()
-                                .compressed_size.parse().unwrap(),
+                            downloaded_size: diff_info
+                                .stats
+                                .get(&current.to_string())
+                                .unwrap()
+                                .compressed_size
+                                .parse()
+                                .unwrap(),
 
-                            unpacked_size: diff_info.stats.get(&current.to_string()).unwrap()
-                                .uncompressed_size.parse().unwrap(),
+                            unpacked_size: diff_info
+                                .stats
+                                .get(&current.to_string())
+                                .unwrap()
+                                .uncompressed_size
+                                .parse()
+                                .unwrap(),
 
                             download_info: sophon::api_schemas::DownloadOrDiff::Patch(diff_info),
                             edition: self.edition,
@@ -267,7 +286,6 @@ impl Game {
                     edition: self.edition
                 })
             }
-
             else {
                 tracing::debug!(
                     current_version = current.to_string(),
@@ -284,7 +302,9 @@ impl Game {
                 if branch_info.main.diff_tags.iter().any(|tag| *tag == current) {
                     for diff in &diffs.manifests {
                         if diff.matching_field == "game" {
-                            if let Some((_, stats)) = diff.stats.iter().find(|(tag, _)| **tag == current) {
+                            if let Some((_, stats)) =
+                                diff.stats.iter().find(|(tag, _)| **tag == current)
+                            {
                                 let downloaded_size = stats.compressed_size.parse()?;
                                 let unpacked_size = stats.uncompressed_size.parse()?;
 
@@ -315,7 +335,6 @@ impl Game {
                 })
             }
         }
-
         else {
             tracing::debug!("Game is not installed");
 
@@ -325,7 +344,8 @@ impl Game {
                 game_edition.into()
             )?;
 
-            let download_info = game_downloads.get_manifests_for("game")
+            let download_info = game_downloads
+                .get_manifests_for("game")
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("failed to get game manifest"))?;
 

--- a/src/games/genshin/repairer.rs
+++ b/src/games/genshin/repairer.rs
@@ -35,7 +35,10 @@ fn try_get_some_integrity_files(
 
     let downloads = sophon::installer::get_game_download_sophon_info(
         &client,
-        &game_branch_info.main,
+        game_branch_info
+            .main
+            .as_ref()
+            .expect("The `None` case would have been caught earlier"),
         game_edition.into()
     )?;
 

--- a/src/games/genshin/repairer.rs
+++ b/src/games/genshin/repairer.rs
@@ -4,7 +4,6 @@ use cached::proc_macro::cached;
 
 use crate::repairer::IntegrityFile;
 use crate::sophon;
-
 use super::consts::GameEdition;
 use super::voice_data::locale::VoiceLocale;
 
@@ -19,13 +18,15 @@ fn try_get_some_integrity_files(
 
     let game_branches = sophon::get_game_branches_info(&client, game_edition.into())?;
 
-    let latest_version = game_branches.latest_version_by_id(game_edition.game_id())
+    let latest_version = game_branches
+        .latest_version_by_id(game_edition.game_id())
         .ok_or_else(|| {
             anyhow::anyhow!("failed to find the latest game version")
                 .context(format!("game id: {}", game_edition.game_id()))
         })?;
 
-    let game_branch_info = game_branches.get_game_by_id(game_edition.game_id(), latest_version)
+    let game_branch_info = game_branches
+        .get_game_by_id(game_edition.game_id(), latest_version)
         .ok_or_else(|| {
             anyhow::anyhow!("failed to get the game version information")
                 .context(format!("game id: {}", game_edition.game_id()))
@@ -38,7 +39,9 @@ fn try_get_some_integrity_files(
         game_edition.into()
     )?;
 
-    let download_info = downloads.manifests.iter()
+    let download_info = downloads
+        .manifests
+        .iter()
         .find(|download_info| download_info.matching_field == matching_field)
         .ok_or_else(|| {
             anyhow::anyhow!("failed to find game download info")
@@ -47,7 +50,9 @@ fn try_get_some_integrity_files(
 
     let download_manifest = sophon::installer::get_download_manifest(&client, download_info)?;
 
-    let files = download_manifest.Assets.iter()
+    let files = download_manifest
+        .Assets
+        .iter()
         .map(IntegrityFile::from)
         .collect::<Vec<_>>();
 
@@ -77,7 +82,8 @@ pub fn try_get_voice_integrity_files(
 ///
 /// `relative_path` must be relative to the game's root folder, so if your file
 /// is e.g. `/path/to/[AnimeGame]/[AnimeGame_Data]/level0`, then root folder is
-/// `/path/to/[AnimeGame]`, and `relative_path` must be `[AnimeGame_Data]/level0`.
+/// `/path/to/[AnimeGame]`, and `relative_path` must be
+/// `[AnimeGame_Data]/level0`.
 pub fn try_get_integrity_file(
     game_edition: GameEdition,
     relative_path: impl AsRef<Path>,
@@ -127,7 +133,7 @@ pub fn try_get_unused_files(
         String::from("webCaches"),
         String::from("SDKCaches"),
         String::from("GeneratedSoundBanks"),
-        String::from("ScreenShot"),
+        String::from("ScreenShot")
     ];
 
     crate::repairer::try_get_unused_files(game_dir, used_files, skip_names)

--- a/src/games/genshin/voice_data/package.rs
+++ b/src/games/genshin/voice_data/package.rs
@@ -184,7 +184,10 @@ impl VoicePackage {
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
-            &game_branch_info.main,
+            game_branch_info
+                .main
+                .as_ref()
+                .expect("The `None` case would have been caught earlier"),
             game_edition.into()
         )?;
 
@@ -287,7 +290,10 @@ impl VoicePackage {
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
-            &branch_info.main,
+            branch_info
+                .main
+                .as_ref()
+                .expect("The `None` case would have been caught earlier"),
             game_edition.into()
         )?;
 
@@ -368,15 +374,21 @@ impl VoicePackage {
                         let mut voice_packages_sizes = get_voice_pack_sizes(*locale);
 
                         // Get the latest game version's voice pack sizes from the API
-                        if !voice_packages_sizes
-                            .iter()
-                            .any(|(tag, _)| *tag == game_branch_info.main.tag)
-                        {
+                        if !voice_packages_sizes.iter().any(|(tag, _)| {
+                            *tag == game_branch_info
+                                .main
+                                .as_ref()
+                                .expect("The `None` case would have been caught earlier")
+                                .tag
+                        }) {
                             let locale = locale.to_code();
 
                             let download_info = sophon::installer::get_game_download_sophon_info(
                                 &client,
-                                &game_branch_info.main,
+                                game_branch_info
+                                    .main
+                                    .as_ref()
+                                    .expect("The `None` case would have been caught earlier"),
                                 (*game_edition).into()
                             )?;
 
@@ -390,17 +402,39 @@ impl VoicePackage {
 
                                 // Inserting at `0` so that it gets picked up at the next bit of
                                 // code, doesn't have to predict.
-                                voice_packages_sizes.insert(0, (&game_branch_info.main.tag, size));
+                                voice_packages_sizes.insert(
+                                    0,
+                                    (
+                                        &game_branch_info
+                                            .main
+                                            .as_ref()
+                                            .expect(
+                                                "The `None` case would have been caught earlier"
+                                            )
+                                            .tag,
+                                        size
+                                    )
+                                );
                             }
                         }
 
                         // If latest voice packages sizes aren't listed in `VOICE_PACKAGES_SIZES`
                         // then we should predict their sizes
-                        if VOICE_PACKAGES_SIZES[0].0 != game_branch_info.main.tag {
+                        if VOICE_PACKAGES_SIZES[0].0
+                            != game_branch_info
+                                .main
+                                .as_ref()
+                                .expect("The `None` case would have been caught earlier")
+                                .tag
+                        {
                             let mut t = voice_packages_sizes;
 
                             voice_packages_sizes = vec![(
-                                &game_branch_info.main.tag,
+                                &game_branch_info
+                                    .main
+                                    .as_ref()
+                                    .expect("The `None` case would have been caught earlier")
+                                    .tag,
                                 predict_new_voice_pack_size(*locale)
                             )];
                             voice_packages_sizes.append(&mut t);
@@ -526,7 +560,10 @@ impl VoicePackage {
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
-            &branch_info.main,
+            branch_info
+                .main
+                .as_ref()
+                .expect("The `None` case would have been caught earlier"),
             game_edition.into()
         )?;
 
@@ -613,10 +650,20 @@ impl VoicePackage {
                     "Voice package is outdated"
                 );
 
-                if branch_info.main.diff_tags.iter().any(|tag| *tag == current) {
+                if branch_info
+                    .main
+                    .as_ref()
+                    .expect("The `None` case would have been caught earlier")
+                    .diff_tags
+                    .iter()
+                    .any(|tag| *tag == current)
+                {
                     let game_patches = sophon::updater::get_game_diffs_sophon_info(
                         &client,
-                        &branch_info.main,
+                        branch_info
+                            .main
+                            .as_ref()
+                            .expect("The `None` case would have been caught earlier"),
                         game_edition.into()
                     )?;
 

--- a/src/games/genshin/voice_data/package.rs
+++ b/src/games/genshin/voice_data/package.rs
@@ -3,15 +3,11 @@ use std::path::{Path, PathBuf};
 use fs_extra::dir::get_size;
 
 use crate::version::Version;
-use crate::sophon::api_schemas::{
-    sophon_diff::SophonDiff,
-    sophon_manifests::SophonDownloadInfo
-};
+use crate::sophon::api_schemas::sophon_diff::SophonDiff;
+use crate::sophon::api_schemas::sophon_manifests::SophonDownloadInfo;
 use crate::sophon;
-
 use crate::genshin::consts::*;
 use crate::genshin::voice_data::locale::VoiceLocale;
-
 #[cfg(feature = "install")]
 use crate::genshin::version_diff::*;
 
@@ -53,14 +49,15 @@ pub const VOICE_PACKAGE_THRESHOLD: u64 = 400 * 1024 * 1024; // 400 MB, ~4 files
 
 /// Get specific voice package sizes from `VOICE_PACKAGES_SIZES` constant
 pub fn get_voice_pack_sizes<'a>(locale: VoiceLocale) -> Vec<(&'a str, u64)> {
-    VOICE_PACKAGES_SIZES.iter().map(|item| {
-        match locale {
-            VoiceLocale::English  => (item.0, item.1),
+    VOICE_PACKAGES_SIZES
+        .iter()
+        .map(|item| match locale {
+            VoiceLocale::English => (item.0, item.1),
             VoiceLocale::Japanese => (item.0, item.2),
-            VoiceLocale::Korean   => (item.0, item.3),
-            VoiceLocale::Chinese  => (item.0, item.4)
-        }
-    }).collect()
+            VoiceLocale::Korean => (item.0, item.3),
+            VoiceLocale::Chinese => (item.0, item.4)
+        })
+        .collect()
 }
 
 /// Predict next value of slice using WMA
@@ -84,9 +81,16 @@ pub fn wma_predict(values: &[u64]) -> u64 {
     }
 }
 
-/// Predict new voice package size using WMA based on `VOICE_PACKAGES_SIZES` constant
+/// Predict new voice package size using WMA based on `VOICE_PACKAGES_SIZES`
+/// constant
 pub fn predict_new_voice_pack_size(locale: VoiceLocale) -> u64 {
-    wma_predict(&get_voice_pack_sizes(locale).into_iter().map(|item| item.1).rev().collect::<Vec<u64>>())
+    wma_predict(
+        &get_voice_pack_sizes(locale)
+            .into_iter()
+            .map(|item| item.1)
+            .rev()
+            .collect::<Vec<u64>>()
+    )
 }
 
 /// Find voice package with specified locale from list of packages
@@ -97,7 +101,8 @@ fn find_voice_pack(list: &[SophonDownloadInfo], locale: VoiceLocale) -> SophonDo
         }
     }
 
-    // We're sure that all possible voice packages are listed in VoiceLocale... right?
+    // We're sure that all possible voice packages are listed in VoiceLocale...
+    // right?
     unreachable!();
 }
 
@@ -109,7 +114,8 @@ fn find_voice_pack_diff(list: &[SophonDiff], locale: VoiceLocale) -> SophonDiff 
         }
     }
 
-    // We're sure that all possible voice packages are listed in VoiceLocale... right?
+    // We're sure that all possible voice packages are listed in VoiceLocale...
+    // right?
     unreachable!();
 }
 
@@ -141,14 +147,11 @@ impl VoicePackage {
         if path.is_dir() {
             let name = path.file_name()?;
 
-            return VoiceLocale::from_str(name.to_string_lossy())
-                .map(|locale| {
-                    Self::Installed {
-                        path,
-                        locale,
-                        game_edition
-                    }
-                });
+            return VoiceLocale::from_str(name.to_string_lossy()).map(|locale| Self::Installed {
+                path,
+                locale,
+                game_edition
+            });
         }
 
         None
@@ -157,26 +160,27 @@ impl VoicePackage {
     /// Get latest voice package with specified locale
     ///
     /// Note that returned object will be `VoicePackage::NotInstalled`, but
-    /// technically it can be installed. This method just don't know the game's path
+    /// technically it can be installed. This method just don't know the game's
+    /// path
     pub fn with_locale(locale: VoiceLocale, game_edition: GameEdition) -> anyhow::Result<Self> {
         let client = reqwest::blocking::Client::new();
 
         let game_branches = sophon::get_game_branches_info(&client, game_edition.into())?;
 
-        let latest_version = game_branches.latest_version_by_id(game_edition.game_id())
+        let latest_version = game_branches
+            .latest_version_by_id(game_edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to find the latest game version")
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let game_branch_info = game_branches.get_game_by_id(
-            game_edition.game_id(),
-            latest_version
-        ).ok_or_else(|| {
-            anyhow::anyhow!("failed to get the game version information")
-                .context(format!("game id: {}", game_edition.game_id()))
-                .context(format!("game version: {latest_version}"))
-        })?;
+        let game_branch_info = game_branches
+            .get_game_by_id(game_edition.game_id(), latest_version)
+            .ok_or_else(|| {
+                anyhow::anyhow!("failed to get the game version information")
+                    .context(format!("game id: {}", game_edition.game_id()))
+                    .context(format!("game version: {latest_version}"))
+            })?;
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
@@ -196,8 +200,12 @@ impl VoicePackage {
     #[inline]
     pub fn game_edition(&self) -> GameEdition {
         match self {
-            Self::Installed { game_edition, .. } |
-            Self::NotInstalled { game_edition, .. } => *game_edition
+            Self::Installed {
+                game_edition, ..
+            }
+            | Self::NotInstalled {
+                game_edition, ..
+            } => *game_edition
         }
     }
 
@@ -205,14 +213,20 @@ impl VoicePackage {
 
     /// Get installation status of this package
     ///
-    /// This method will return `false` if this package is `VoicePackage::NotInstalled` enum value
+    /// This method will return `false` if this package is
+    /// `VoicePackage::NotInstalled` enum value
     ///
-    /// If you want to check it's actually installed - you'd need to use `is_installed_in`
+    /// If you want to check it's actually installed - you'd need to use
+    /// `is_installed_in`
     #[inline]
     pub fn is_installed(&self) -> bool {
         match self {
-            Self::Installed { .. } => true,
-            Self::NotInstalled { .. } => false
+            Self::Installed {
+                ..
+            } => true,
+            Self::NotInstalled {
+                ..
+            } => false
         }
     }
 
@@ -221,22 +235,32 @@ impl VoicePackage {
     /// (unpacked size, Option(archive size))
     pub fn size(&self) -> (u64, Option<u64>) {
         match self {
-            VoicePackage::Installed { path, .. } => (get_size(path).unwrap(), None),
-            VoicePackage::NotInstalled { data, .. } => (
+            VoicePackage::Installed {
+                path, ..
+            } => (get_size(path).unwrap(), None),
+            VoicePackage::NotInstalled {
+                data, ..
+            } => (
                 data.stats.compressed_size.parse::<u64>().unwrap(),
                 Some(data.stats.uncompressed_size.parse::<u64>().unwrap())
             )
         }
     }
 
-    /// This method will return `true` if the package has `VoicePackage::Installed` enum value
+    /// This method will return `true` if the package has
+    /// `VoicePackage::Installed` enum value
     ///
-    /// If it's `VoicePackage::NotInstalled`, then this method will check `game_path`'s voices folder
+    /// If it's `VoicePackage::NotInstalled`, then this method will check
+    /// `game_path`'s voices folder
     #[inline]
     pub fn is_installed_in<T: AsRef<Path>>(&self, game_path: T) -> bool {
         match self {
-            Self::Installed { .. } => true,
-            Self::NotInstalled { locale, .. } => get_voice_package_path(game_path, self.game_edition(), *locale).exists()
+            Self::Installed {
+                ..
+            } => true,
+            Self::NotInstalled {
+                locale, ..
+            } => get_voice_package_path(game_path, self.game_edition(), *locale).exists()
         }
     }
 
@@ -246,20 +270,20 @@ impl VoicePackage {
 
         let game_branches = sophon::get_game_branches_info(&client, game_edition.into())?;
 
-        let latest_version = game_branches.latest_version_by_id(game_edition.game_id())
+        let latest_version = game_branches
+            .latest_version_by_id(game_edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to find the latest game version")
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let branch_info = game_branches.get_game_by_id(
-            game_edition.game_id(),
-            latest_version
-        ).ok_or_else(|| {
-            anyhow::anyhow!("failed to get the game version information")
-                .context(format!("game id: {}", game_edition.game_id()))
-                .context(format!("game version: {latest_version}"))
-        })?;
+        let branch_info = game_branches
+            .get_game_by_id(game_edition.game_id(), latest_version)
+            .ok_or_else(|| {
+                anyhow::anyhow!("failed to get the game version information")
+                    .context(format!("game id: {}", game_edition.game_id()))
+                    .context(format!("game version: {latest_version}"))
+            })?;
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
@@ -288,8 +312,12 @@ impl VoicePackage {
     #[inline]
     pub fn locale(&self) -> VoiceLocale {
         match self {
-            Self::Installed { locale, .. } |
-            Self::NotInstalled { locale, .. } => *locale
+            Self::Installed {
+                locale, ..
+            }
+            | Self::NotInstalled {
+                locale, ..
+            } => *locale
         }
     }
 
@@ -303,9 +331,15 @@ impl VoicePackage {
         let client = reqwest::blocking::Client::new();
 
         match &self {
-            Self::NotInstalled { version, .. } => Ok(*version),
+            Self::NotInstalled {
+                version, ..
+            } => Ok(*version),
 
-            Self::Installed { path, locale, game_edition } => {
+            Self::Installed {
+                path,
+                locale,
+                game_edition
+            } => {
                 match std::fs::read(path.join(".version")) {
                     Ok(curr) => {
                         tracing::debug!("Found .version file: {}.{}.{}", curr[0], curr[1], curr[2]);
@@ -319,20 +353,25 @@ impl VoicePackage {
                     Err(_) => {
                         let package_size = get_size(path)?;
 
-                        let game_branches = sophon::get_game_branches_info(
-                            &client,
-                            (*game_edition).into()
-                        )?;
+                        let game_branches =
+                            sophon::get_game_branches_info(&client, (*game_edition).into())?;
 
-                        let game_branch_info = game_branches.get_game_latest_by_id(game_edition.game_id())
+                        let game_branch_info = game_branches
+                            .get_game_latest_by_id(game_edition.game_id())
                             .expect("Latest version should be available");
 
-                        tracing::debug!(package_size, ".version file wasn't found, predicting voiceover version");
+                        tracing::debug!(
+                            package_size,
+                            ".version file wasn't found, predicting voiceover version"
+                        );
 
                         let mut voice_packages_sizes = get_voice_pack_sizes(*locale);
 
                         // Get the latest game version's voice pack sizes from the API
-                        if !voice_packages_sizes.iter().any(|(tag, _)| *tag == game_branch_info.main.tag) {
+                        if !voice_packages_sizes
+                            .iter()
+                            .any(|(tag, _)| *tag == game_branch_info.main.tag)
+                        {
                             let locale = locale.to_code();
 
                             let download_info = sophon::installer::get_game_download_sophon_info(
@@ -341,7 +380,9 @@ impl VoicePackage {
                                 (*game_edition).into()
                             )?;
 
-                            let info = download_info.manifests.iter()
+                            let info = download_info
+                                .manifests
+                                .iter()
                                 .find(|download_info| download_info.matching_field == locale);
 
                             if let Some(api_size) = info {
@@ -358,12 +399,17 @@ impl VoicePackage {
                         if VOICE_PACKAGES_SIZES[0].0 != game_branch_info.main.tag {
                             let mut t = voice_packages_sizes;
 
-                            voice_packages_sizes = vec![(&game_branch_info.main.tag, predict_new_voice_pack_size(*locale))];
+                            voice_packages_sizes = vec![(
+                                &game_branch_info.main.tag,
+                                predict_new_voice_pack_size(*locale)
+                            )];
                             voice_packages_sizes.append(&mut t);
                         }
 
-                        // To predict voice package version we're going through saved voice packages sizes in the `VOICE_PACKAGES_SIZES` constant
-                        // plus predicted voice packages sizes if needed. The version with closest folder size is version we have installed
+                        // To predict voice package version we're going through saved voice packages
+                        // sizes in the `VOICE_PACKAGES_SIZES` constant plus
+                        // predicted voice packages sizes if needed. The version with closest folder
+                        // size is version we have installed
                         for (version, size) in voice_packages_sizes {
                             if package_size > size - VOICE_PACKAGE_THRESHOLD {
                                 tracing::debug!("Predicted version: {version}");
@@ -388,7 +434,9 @@ impl VoicePackage {
         tracing::trace!(locale = ?self.locale(), "Deleting voice package");
 
         match self {
-            VoicePackage::Installed { path, .. } => {
+            VoicePackage::Installed {
+                path, ..
+            } => {
                 let mut game_path = path.clone();
 
                 for _ in 0..4 {
@@ -406,15 +454,15 @@ impl VoicePackage {
                 self.delete_in(game_path)?;
             }
 
-            VoicePackage::NotInstalled { game_path, .. } => {
-                match game_path {
-                    Some(game_path) => self.delete_in(game_path)?,
+            VoicePackage::NotInstalled {
+                game_path, ..
+            } => match game_path {
+                Some(game_path) => self.delete_in(game_path)?,
 
-                    None => {
-                        tracing::error!("Failed to find game directory");
+                None => {
+                    tracing::error!("Failed to find game directory");
 
-                        anyhow::bail!("Failed to find game directory");
-                    }
+                    anyhow::bail!("Failed to find game directory");
                 }
             }
         }
@@ -427,14 +475,21 @@ impl VoicePackage {
     ///
     /// FIXME:
     /// ⚠️ May fail on Chinese version due to paths differences
-    pub fn delete_in<T: Into<PathBuf> + std::fmt::Debug>(&self, game_path: T) -> anyhow::Result<()> {
+    pub fn delete_in<T: Into<PathBuf> + std::fmt::Debug>(
+        &self,
+        game_path: T
+    ) -> anyhow::Result<()> {
         let game_path = game_path.into();
         let locale = self.locale();
 
         tracing::debug!(?locale, "Deleting voice package");
 
         // Audio_<locale folder>_pkg_version
-        std::fs::remove_dir_all(get_voice_package_path(&game_path, self.game_edition(), locale))?;
+        std::fs::remove_dir_all(get_voice_package_path(
+            &game_path,
+            self.game_edition(),
+            locale
+        ))?;
         std::fs::remove_file(game_path.join(format!("Audio_{}_pkg_version", locale.to_folder())))?;
 
         Ok(())
@@ -443,7 +498,10 @@ impl VoicePackage {
     #[cfg(feature = "install")]
     #[tracing::instrument(level = "debug", ret)]
     pub fn try_get_diff(&self) -> anyhow::Result<VersionDiff> {
-        tracing::debug!("Trying to find version diff for {} voice package", self.locale().to_code());
+        tracing::debug!(
+            "Trying to find version diff for {} voice package",
+            self.locale().to_code()
+        );
 
         let game_edition = self.game_edition();
 
@@ -451,20 +509,20 @@ impl VoicePackage {
 
         let game_branches = sophon::get_game_branches_info(&client, game_edition.into())?;
 
-        let latest_version = game_branches.latest_version_by_id(game_edition.game_id())
+        let latest_version = game_branches
+            .latest_version_by_id(game_edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to find the latest game version")
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let branch_info = game_branches.get_game_by_id(
-            game_edition.game_id(),
-            latest_version
-        ).ok_or_else(|| {
-            anyhow::anyhow!("failed to get the game version information")
-                .context(format!("game id: {}", game_edition.game_id()))
-                .context(format!("game version: {latest_version}"))
-        })?;
+        let branch_info = game_branches
+            .get_game_by_id(game_edition.game_id(), latest_version)
+            .ok_or_else(|| {
+                anyhow::anyhow!("failed to get the game version information")
+                    .context(format!("game id: {}", game_edition.game_id()))
+                    .context(format!("game version: {latest_version}"))
+            })?;
 
         let downloads_info = sophon::installer::get_game_download_sophon_info(
             &client,
@@ -484,7 +542,11 @@ impl VoicePackage {
                 // (which is not possible in reality) we should just say thath the game
                 // is latest
                 if let Some(predownload_info) = &branch_info.pre_download {
-                    if predownload_info.diff_tags.iter().any(|pre_ver| *pre_ver == current) {
+                    if predownload_info
+                        .diff_tags
+                        .iter()
+                        .any(|pre_ver| *pre_ver == current)
+                    {
                         let game_patches = sophon::updater::get_game_diffs_sophon_info(
                             &client,
                             predownload_info,
@@ -493,11 +555,14 @@ impl VoicePackage {
 
                         let diff = find_voice_pack_diff(&game_patches.manifests, self.locale());
 
-                        let stats = diff.stats.get(&current.to_string())
+                        let stats = diff
+                            .stats
+                            .get(&current.to_string())
                             .ok_or_else(|| anyhow::anyhow!("failed to get voiceover diff stats"))?;
 
-                        let predownload_version = predownload_info.version()
-                            .ok_or_else(|| anyhow::anyhow!("failed to get predownload game version"))?;
+                        let predownload_version = predownload_info.version().ok_or_else(|| {
+                            anyhow::anyhow!("failed to get predownload game version")
+                        })?;
 
                         return Ok(VersionDiff::Predownload {
                             current,
@@ -509,24 +574,30 @@ impl VoicePackage {
                             download_info: sophon::api_schemas::DownloadOrDiff::Patch(diff),
 
                             installation_path: match self {
-                                VoicePackage::Installed { .. } => None,
-                                VoicePackage::NotInstalled { game_path, .. } => game_path.clone()
+                                VoicePackage::Installed {
+                                    ..
+                                } => None,
+                                VoicePackage::NotInstalled {
+                                    game_path, ..
+                                } => game_path.clone()
                             },
 
                             version_file_path: match self {
-                                VoicePackage::Installed { path, .. } => Some(path.join(".version")),
+                                VoicePackage::Installed {
+                                    path, ..
+                                } => Some(path.join(".version")),
 
-                                VoicePackage::NotInstalled { game_path, .. } => {
-                                    game_path.as_ref().map(|game_path| {
-                                        get_voice_package_path(game_path, game_edition, self.locale())
-                                            .join(".version")
-                                    })
-                                }
+                                VoicePackage::NotInstalled {
+                                    game_path, ..
+                                } => game_path.as_ref().map(|game_path| {
+                                    get_voice_package_path(game_path, game_edition, self.locale())
+                                        .join(".version")
+                                })
                             },
 
                             temp_folder: None,
                             edition: game_edition
-                        })
+                        });
                     }
                 }
 
@@ -535,7 +606,6 @@ impl VoicePackage {
                     edition: game_edition
                 })
             }
-
             else {
                 tracing::debug!(
                     current_version = current.to_string(),
@@ -552,7 +622,9 @@ impl VoicePackage {
 
                     let diff = find_voice_pack_diff(&game_patches.manifests, self.locale());
 
-                    let current_ver_patch_stats = diff.stats.get(&current.to_string())
+                    let current_ver_patch_stats = diff
+                        .stats
+                        .get(&current.to_string())
                         .ok_or_else(|| anyhow::anyhow!("failed to get voiceover diff stats"))?;
 
                     return Ok(VersionDiff::Diff {
@@ -564,24 +636,30 @@ impl VoicePackage {
                         diff,
 
                         installation_path: match self {
-                            VoicePackage::Installed { .. } => None,
-                            VoicePackage::NotInstalled { game_path, .. } => game_path.clone()
+                            VoicePackage::Installed {
+                                ..
+                            } => None,
+                            VoicePackage::NotInstalled {
+                                game_path, ..
+                            } => game_path.clone()
                         },
 
                         version_file_path: match self {
-                            VoicePackage::Installed { path, .. } => Some(path.join(".version")),
+                            VoicePackage::Installed {
+                                path, ..
+                            } => Some(path.join(".version")),
 
-                            VoicePackage::NotInstalled { game_path, .. } => {
-                                game_path.as_ref().map(|game_path| {
-                                    get_voice_package_path(game_path, game_edition, self.locale())
-                                        .join(".version")
-                                })
-                            }
+                            VoicePackage::NotInstalled {
+                                game_path, ..
+                            } => game_path.as_ref().map(|game_path| {
+                                get_voice_package_path(game_path, game_edition, self.locale())
+                                    .join(".version")
+                            })
                         },
 
                         temp_folder: None,
                         edition: game_edition
-                    })
+                    });
                 }
 
                 Ok(VersionDiff::Outdated {
@@ -591,7 +669,6 @@ impl VoicePackage {
                 })
             }
         }
-
         else {
             tracing::debug!("Package is not installed");
 
@@ -605,19 +682,25 @@ impl VoicePackage {
                 download_info: latest,
 
                 installation_path: match self {
-                    VoicePackage::Installed { .. } => None,
-                    VoicePackage::NotInstalled { game_path, .. } => game_path.clone()
+                    VoicePackage::Installed {
+                        ..
+                    } => None,
+                    VoicePackage::NotInstalled {
+                        game_path, ..
+                    } => game_path.clone()
                 },
 
                 version_file_path: match self {
-                    VoicePackage::Installed { path, .. } => Some(path.join(".version")),
+                    VoicePackage::Installed {
+                        path, ..
+                    } => Some(path.join(".version")),
 
-                    VoicePackage::NotInstalled { game_path, .. } => {
-                        game_path.as_ref().map(|game_path| {
-                            get_voice_package_path(game_path, game_edition, self.locale())
-                                .join(".version")
-                        })
-                    }
+                    VoicePackage::NotInstalled {
+                        game_path, ..
+                    } => game_path.as_ref().map(|game_path| {
+                        get_voice_package_path(game_path, game_edition, self.locale())
+                            .join(".version")
+                    })
                 },
 
                 temp_folder: None,


### PR DESCRIPTION
It turns out the `main` field can be `null`. This is a slightly dirty fix because of how many places use `.expect` now, but in all cases it is guaranteed that the `None` case would've been caught when searching for the latest version.