### PR TITLE
Change .version file format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,5 @@ all = [
     "patches"
 ]
 
-default = ["all", "star-rail", "patch-jadeite"]
-
 [build-dependencies]
 protobuf-codegen = { version = "3.7.2", optional = true }

--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -12,6 +12,28 @@ use super::version_diff::*;
 use super::voice_data::locale::VoiceLocale;
 use super::voice_data::package::VoicePackage;
 
+fn parse_dotversion(path: &Path) -> Option<Version> {
+    std::fs::read(path)
+        .map(|version| {
+            if version.len() == 3 {
+                tracing::info!("Found old format version file");
+                Some(Version::new(version[0], version[1], version[2]))
+            }
+            else if version.len() > 3 {
+                String::from_utf8(version)
+                    .map(|version_str| Version::from_str(&version_str))
+                    .ok()
+                    .flatten()
+            }
+            else {
+                tracing::error!(?path, "The `.version` file is too short!");
+                None
+            }
+        })
+        .ok()
+        .flatten()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Game {
     path: PathBuf,
@@ -68,9 +90,8 @@ impl GameExt for Game {
             bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
         }
 
-        let stored_version = std::fs::read(self.path.join(".version"))
-            .map(|version| Version::new(version[0], version[1], version[2]))
-            .ok();
+        let stored_version_path = self.path.join(".version");
+        let stored_version = parse_dotversion(&stored_version_path);
 
         let path = self
             .path

--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -184,7 +184,10 @@ impl Game {
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let latest_version: Version = branch_info.version().expect("must be a valid version").into();
+        let latest_version: Version = branch_info
+            .version()
+            .expect("must be a valid version")
+            .into();
 
         if self.is_installed() {
             let current = match self.get_version() {

--- a/src/games/genshin/version_diff.rs
+++ b/src/games/genshin/version_diff.rs
@@ -308,7 +308,7 @@ impl VersionDiff {
                 .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         tracing::debug!(
@@ -353,7 +353,7 @@ impl VersionDiff {
                 .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         tracing::debug!(

--- a/src/games/genshin/voice_data/package.rs
+++ b/src/games/genshin/voice_data/package.rs
@@ -15,6 +15,7 @@ use crate::genshin::version_diff::*;
 /// List of voiceover sizes
 ///
 /// Format: `(version, english, japanese, korean, chinese)`
+#[rustfmt::skip]
 pub const VOICE_PACKAGES_SIZES: &[(&str, u64, u64, u64, u64)] = &[
     //         English(US)   Japanese      Korean        Chinese
     ("5.7.0",  19512988499,  22222747101,  16908205123,  17127113750),
@@ -168,7 +169,8 @@ impl VoicePackage {
 
         let game_branches = sophon::api::get_game_branches_info(&client, &game_edition.into())?;
 
-        let game_branch_info = game_branches.get_game_branch_by_id_or_biz_latest(game_edition.game_id())
+        let game_branch_info = game_branches
+            .get_game_branch_by_id_or_biz_latest(game_edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to get the game version information")
                     .context(format!("game id: {}", game_edition.game_id()))
@@ -185,7 +187,10 @@ impl VoicePackage {
 
         Ok(Self::NotInstalled {
             locale,
-            version: game_branch_info.version().expect("must be valid version").into(),
+            version: game_branch_info
+                .version()
+                .expect("must be valid version")
+                .into(),
             data: find_voice_pack(&downloads_info.manifests, locale),
             game_path: None,
             game_edition
@@ -265,7 +270,8 @@ impl VoicePackage {
 
         let game_branches = sophon::api::get_game_branches_info(&client, &game_edition.into())?;
 
-        let branch_info = game_branches.get_game_branch_by_id_or_biz_latest(game_edition.game_id())
+        let branch_info = game_branches
+            .get_game_branch_by_id_or_biz_latest(game_edition.game_id())
             .ok_or_else(|| {
                 anyhow::anyhow!("failed to get the game version information")
                     .context(format!("game id: {}", game_edition.game_id()))
@@ -286,7 +292,10 @@ impl VoicePackage {
             if let Some(locale) = VoiceLocale::from_str(&package.matching_field) {
                 packages.push(Self::NotInstalled {
                     locale,
-                    version: branch_info.version().expect("must be a valid version").into(),
+                    version: branch_info
+                        .version()
+                        .expect("must be a valid version")
+                        .into(),
                     data: package.clone(),
                     game_path: None,
                     game_edition
@@ -533,7 +542,10 @@ impl VoicePackage {
                     .context(format!("game id: {}", game_edition.game_id()))
             })?;
 
-        let latest_version: Version = branch_info.version().expect("must be a valid version").into();
+        let latest_version: Version = branch_info
+            .version()
+            .expect("must be a valid version")
+            .into();
 
         let downloads_info = sophon::api::get_game_download_sophon_info(
             &client,

--- a/src/games/genshin/voice_data/package.rs
+++ b/src/games/genshin/voice_data/package.rs
@@ -340,9 +340,22 @@ impl VoicePackage {
             } => {
                 match std::fs::read(path.join(".version")) {
                     Ok(curr) => {
-                        tracing::debug!("Found .version file: {}.{}.{}", curr[0], curr[1], curr[2]);
+                        tracing::debug!("Found .version file");
+                        if curr.len() == 3 {
+                            tracing::info!("Found old format version file");
+                            let parsed_ver = Version::new(curr[0], curr[1], curr[2]);
+                            Ok(parsed_ver)
+                        }
+                        else if curr.len() > 3 {
+                            let version_str = String::from_utf8(curr)?;
 
-                        Ok(Version::new(curr[0], curr[1], curr[2]))
+                            Version::from_str(&version_str).ok_or_else(|| {
+                                anyhow::anyhow!("Invalid version string: {version_str}")
+                            })
+                        }
+                        else {
+                            Err(anyhow::anyhow!("The `.version` file is too short"))
+                        }
                     }
 
                     // We don't create .version file here because we don't

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use crate::version::Version;
 use crate::traits::game::GameExt;
-
 use super::api;
 use super::consts::*;
 use super::version_diff::*;
@@ -57,7 +56,11 @@ impl GameExt for Game {
             .map(|version| Version::new(version[0], version[1], version[2]))
             .ok();
 
-        let file = File::open(self.path.join(self.edition.data_folder()).join("globalgamemanagers"))?;
+        let file = File::open(
+            self.path
+                .join(self.edition.data_folder())
+                .join("globalgamemanagers")
+        )?;
 
         let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
         let mut version_ptr: usize = 0;
@@ -67,13 +70,18 @@ impl GameExt for Game {
             if let Ok(byte) = byte {
                 match byte {
                     0 => {
-                        if correct && version_ptr == 2 && version[0].len() > 0 && version[1].len() > 0 && version[2].len() > 0 {
+                        if correct
+                            && version_ptr == 2
+                            && version[0].len() > 0
+                            && version[1].len() > 0
+                            && version[2].len() > 0
+                        {
                             let found_version = Version::new(
                                 bytes_to_num(&version[0]),
                                 bytes_to_num(&version[1]),
                                 bytes_to_num(&version[2])
                             );
-    
+
                             // Prioritize version stored in the .version file
                             // because it's parsed from the API directly
                             if let Some(stored_version) = stored_version {
@@ -81,7 +89,7 @@ impl GameExt for Game {
                                     return Ok(stored_version);
                                 }
                             }
-    
+
                             return Ok(found_version);
                         }
 
@@ -102,7 +110,6 @@ impl GameExt for Game {
                         if correct && b"0123456789".contains(&byte) {
                             version[version_ptr].push(byte);
                         }
-
                         else {
                             correct = false;
                         }
@@ -136,9 +143,12 @@ impl Game {
 
                 Ok(VersionDiff::Latest(current))
             }
-
             else {
-                tracing::debug!("Game is outdated: {} -> {}", current, response.main.major.version);
+                tracing::debug!(
+                    "Game is outdated: {} -> {}",
+                    current,
+                    response.main.major.version
+                );
 
                 Ok(VersionDiff::Diff {
                     current,
@@ -147,11 +157,19 @@ impl Game {
                     // TODO: can be a hard issue in future
                     url: response.main.major.game_pkgs[0].url.clone(),
 
-                    downloaded_size: response.main.major.game_pkgs.iter()
+                    downloaded_size: response
+                        .main
+                        .major
+                        .game_pkgs
+                        .iter()
                         .flat_map(|pkg| pkg.size.parse::<u64>())
                         .sum(),
 
-                    unpacked_size: response.main.major.game_pkgs.iter()
+                    unpacked_size: response
+                        .main
+                        .major
+                        .game_pkgs
+                        .iter()
                         .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
                         .sum(),
 
@@ -161,7 +179,6 @@ impl Game {
                 })
             }
         }
-
         else {
             tracing::debug!("Game is not installed");
 
@@ -171,11 +188,19 @@ impl Game {
                 // TODO: can be a hard issue in future
                 url: response.main.major.game_pkgs[0].url.clone(),
 
-                downloaded_size: response.main.major.game_pkgs.iter()
+                downloaded_size: response
+                    .main
+                    .major
+                    .game_pkgs
+                    .iter()
                     .flat_map(|pkg| pkg.size.parse::<u64>())
                     .sum(),
 
-                unpacked_size: response.main.major.game_pkgs.iter()
+                unpacked_size: response
+                    .main
+                    .major
+                    .game_pkgs
+                    .iter()
                     .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
                     .sum(),
 

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -8,6 +8,28 @@ use super::api;
 use super::consts::*;
 use super::version_diff::*;
 
+fn parse_dotversion(path: &Path) -> Option<Version> {
+    std::fs::read(path)
+        .map(|version| {
+            if version.len() == 3 {
+                tracing::info!("Found old format version file");
+                Some(Version::new(version[0], version[1], version[2]))
+            }
+            else if version.len() > 3 {
+                String::from_utf8(version)
+                    .map(|version_str| Version::from_str(&version_str))
+                    .ok()
+                    .flatten()
+            }
+            else {
+                tracing::error!(?path, "The `.version` file is too short!");
+                None
+            }
+        })
+        .ok()
+        .flatten()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Game {
     path: PathBuf,
@@ -52,9 +74,8 @@ impl GameExt for Game {
             bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - '0' as u8))
         }
 
-        let stored_version = std::fs::read(self.path.join(".version"))
-            .map(|version| Version::new(version[0], version[1], version[2]))
-            .ok();
+        let stored_version_path = self.path.join(".version");
+        let stored_version = parse_dotversion(&stored_version_path);
 
         let file = File::open(
             self.path

--- a/src/games/honkai/version_diff.rs
+++ b/src/games/honkai/version_diff.rs
@@ -1,19 +1,15 @@
 use std::path::{Path, PathBuf};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::version::Version;
 use crate::traits::version_diff::VersionDiffExt;
-
 #[cfg(feature = "install")]
 use crate::installer::{
     downloader::{Downloader, DownloadingError},
-    installer::{
-        Installer,
-        Update as InstallerUpdate
-    },
-    free_space
+    free_space,
+    installer::{Installer, Update as InstallerUpdate}
 };
 
 #[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,9 +51,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
-        /// 
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -75,9 +73,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
-        /// 
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -96,13 +96,17 @@ impl VersionDiff {
             Self::Latest(_) => None,
 
             // Can be installed
-            Self::Diff { version_file_path, .. } |
-            Self::NotInstalled { version_file_path, .. } => version_file_path.to_owned()
+            Self::Diff {
+                version_file_path, ..
+            }
+            | Self::NotInstalled {
+                version_file_path, ..
+            } => version_file_path.to_owned()
         }
     }
 
     /// Return currently selected temp folder path
-    /// 
+    ///
     /// Default is `std::env::temp_dir()` value
     pub fn temp_folder(&self) -> PathBuf {
         match self {
@@ -110,8 +114,12 @@ impl VersionDiff {
             Self::Latest(_) => std::env::temp_dir(),
 
             // Can be installed
-            Self::Diff { temp_folder, .. } |
-            Self::NotInstalled { temp_folder, .. } => match temp_folder {
+            Self::Diff {
+                temp_folder, ..
+            }
+            | Self::NotInstalled {
+                temp_folder, ..
+            } => match temp_folder {
                 Some(path) => path.to_owned(),
                 None => std::env::temp_dir()
             }
@@ -124,13 +132,17 @@ impl VersionDiff {
             Self::Latest(_) => self,
 
             // Can be installed
-            Self::Diff { temp_folder, .. } => {
+            Self::Diff {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
             }
 
-            Self::NotInstalled { temp_folder, .. } => {
+            Self::NotInstalled {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
@@ -140,9 +152,9 @@ impl VersionDiff {
 }
 
 impl VersionDiffExt for VersionDiff {
+    type Edition = ();
     type Error = DiffDownloadingError;
     type Update = InstallerUpdate;
-    type Edition = ();
 
     #[inline]
     fn edition(&self) -> Self::Edition {
@@ -151,18 +163,26 @@ impl VersionDiffExt for VersionDiff {
 
     fn current(&self) -> Option<Version> {
         match self {
-            Self::Latest(current) |
-            Self::Diff { current, .. } => Some(*current),
+            Self::Latest(current)
+            | Self::Diff {
+                current, ..
+            } => Some(*current),
 
-            Self::NotInstalled { .. } => None
+            Self::NotInstalled {
+                ..
+            } => None
         }
     }
 
     fn latest(&self) -> Version {
         match self {
-            Self::Latest(latest) |
-            Self::Diff { latest, .. } |
-            Self::NotInstalled { latest, .. } => *latest
+            Self::Latest(latest)
+            | Self::Diff {
+                latest, ..
+            }
+            | Self::NotInstalled {
+                latest, ..
+            } => *latest
         }
     }
 
@@ -172,8 +192,12 @@ impl VersionDiffExt for VersionDiff {
             Self::Latest(_) => None,
 
             // Can be installed
-            Self::Diff { downloaded_size, .. } |
-            Self::NotInstalled { downloaded_size, .. } => Some(*downloaded_size)
+            Self::Diff {
+                downloaded_size, ..
+            }
+            | Self::NotInstalled {
+                downloaded_size, ..
+            } => Some(*downloaded_size)
         }
     }
 
@@ -183,8 +207,12 @@ impl VersionDiffExt for VersionDiff {
             Self::Latest(_) => None,
 
             // Can be installed
-            Self::Diff { unpacked_size, .. } |
-            Self::NotInstalled { unpacked_size, .. } => Some(*unpacked_size)
+            Self::Diff {
+                unpacked_size, ..
+            }
+            | Self::NotInstalled {
+                unpacked_size, ..
+            } => Some(*unpacked_size)
         }
     }
 
@@ -194,8 +222,12 @@ impl VersionDiffExt for VersionDiff {
             Self::Latest(_) => None,
 
             // Can be installed
-            Self::Diff { installation_path, .. } |
-            Self::NotInstalled { installation_path, .. } => match installation_path {
+            Self::Diff {
+                installation_path, ..
+            }
+            | Self::NotInstalled {
+                installation_path, ..
+            } => match installation_path {
                 Some(path) => Some(path.as_path()),
                 None => None
             }
@@ -208,12 +240,20 @@ impl VersionDiffExt for VersionDiff {
             Self::Latest(_) => None,
 
             // Can be installed
-            Self::Diff { url, .. } |
-            Self::NotInstalled { url, .. } => Some(url.to_owned())
+            Self::Diff {
+                url, ..
+            }
+            | Self::NotInstalled {
+                url, ..
+            } => Some(url.to_owned())
         }
     }
 
-    fn download_as(&mut self, path: impl AsRef<Path>, progress: impl Fn(u64, u64) + Send + 'static) -> Result<(), Self::Error> {
+    fn download_as(
+        &mut self,
+        path: impl AsRef<Path>,
+        progress: impl Fn(u64, u64) + Send + 'static
+    ) -> Result<(), Self::Error> {
         tracing::debug!("Downloading version difference");
 
         let mut downloader = Downloader::new(match self {
@@ -221,8 +261,12 @@ impl VersionDiffExt for VersionDiff {
             Self::Latest(_) => return Err(Self::Error::AlreadyLatest),
 
             // Can be downloaded
-            Self::Diff { url, .. } |
-            Self::NotInstalled { url, .. } => url
+            Self::Diff {
+                url, ..
+            }
+            | Self::NotInstalled {
+                url, ..
+            } => url
         })?;
 
         if let Err(err) = downloader.download(path.as_ref(), progress) {
@@ -234,26 +278,39 @@ impl VersionDiffExt for VersionDiff {
         Ok(())
     }
 
-    fn install_to(&self, path: impl AsRef<Path>, _thread_count: usize, updater: impl Fn(Self::Update) + Clone + Send + 'static) -> Result<(), Self::Error> {
+    fn install_to(
+        &self,
+        path: impl AsRef<Path>,
+        _thread_count: usize,
+        updater: impl Fn(Self::Update) + Clone + Send + 'static
+    ) -> Result<(), Self::Error> {
         tracing::debug!("Installing version difference");
 
         let path = path.as_ref();
 
-        let url = self.downloading_uri().expect("Failed to retreive downloading url");
-        let downloaded_size = self.downloaded_size().expect("Failed to retreive downloaded size");
-        let unpacked_size = self.unpacked_size().expect("Failed to retreive unpacked size");
+        let url = self
+            .downloading_uri()
+            .expect("Failed to retreive downloading url");
+        let downloaded_size = self
+            .downloaded_size()
+            .expect("Failed to retreive downloaded size");
+        let unpacked_size = self
+            .unpacked_size()
+            .expect("Failed to retreive unpacked size");
 
         let mut installer = Installer::new(url)?
             // Set custom temp folder location
             .with_temp_folder(self.temp_folder())
-
             // Don't perform space checks in the Installer because we're doing it here
             .with_free_space_check(false);
 
-        (updater)(InstallerUpdate::CheckingFreeSpace(installer.temp_folder.to_path_buf()));
+        (updater)(InstallerUpdate::CheckingFreeSpace(
+            installer.temp_folder.to_path_buf()
+        ));
 
         // Check available free space for archive itself
-        let Some(space) = free_space::available(&installer.temp_folder) else {
+        let Some(space) = free_space::available(&installer.temp_folder)
+        else {
             tracing::error!("Path is not mounted: {:?}", installer.temp_folder);
 
             return Err(DownloadingError::PathNotMounted(installer.temp_folder).into());
@@ -262,20 +319,26 @@ impl VersionDiffExt for VersionDiff {
         // We can possibly store downloaded archive + unpacked data on the same disk
         let required = if free_space::is_same_disk(&installer.temp_folder, path) {
             downloaded_size + unpacked_size
-        } else {
+        }
+        else {
             downloaded_size
         };
 
         if space < required {
-            tracing::error!("No free space available in the temp folder. Required: {required}. Available: {space}");
+            tracing::error!(
+                "No free space available in the temp folder. Required: {required}. Available: {space}"
+            );
 
-            return Err(DownloadingError::NoSpaceAvailable(installer.temp_folder, required, space).into());
+            return Err(
+                DownloadingError::NoSpaceAvailable(installer.temp_folder, required, space).into()
+            );
         }
 
         (updater)(InstallerUpdate::CheckingFreeSpace(path.to_path_buf()));
 
         // Check available free space for unpacked archvie data
-        let Some(space) = free_space::available(&path) else {
+        let Some(space) = free_space::available(&path)
+        else {
             tracing::error!("Path is not mounted: {:?}", &path);
 
             return Err(DownloadingError::PathNotMounted(path.to_path_buf()).into());
@@ -284,14 +347,19 @@ impl VersionDiffExt for VersionDiff {
         // We can possibly store downloaded archive + unpacked data on the same disk
         let required = if free_space::is_same_disk(&path, &installer.temp_folder) {
             unpacked_size + downloaded_size
-        } else {
+        }
+        else {
             unpacked_size
         };
 
         if space < required {
-            tracing::error!("No free space available in the installation folder. Required: {required}. Available: {space}");
+            tracing::error!(
+                "No free space available in the installation folder. Required: {required}. Available: {space}"
+            );
 
-            return Err(DownloadingError::NoSpaceAvailable(path.to_path_buf(), required, space).into());
+            return Err(
+                DownloadingError::NoSpaceAvailable(path.to_path_buf(), required, space).into()
+            );
         }
 
         // Install data
@@ -302,8 +370,10 @@ impl VersionDiffExt for VersionDiff {
         // Create `.version` file here even if hdiff patching is failed because
         // it's easier to explain user why he should run files repairer than
         // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)] {
-            let version_path = self.version_file_path()
+        #[allow(unused_must_use)]
+        {
+            let version_path = self
+                .version_file_path()
                 .unwrap_or_else(|| path.join(".version"));
 
             std::fs::write(version_path, self.latest().version);

--- a/src/games/honkai/version_diff.rs
+++ b/src/games/honkai/version_diff.rs
@@ -376,7 +376,7 @@ impl VersionDiffExt for VersionDiff {
                 .version_file_path()
                 .unwrap_or_else(|| path.join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         Ok(())

--- a/src/games/star_rail/game.rs
+++ b/src/games/star_rail/game.rs
@@ -14,6 +14,28 @@ use super::version_diff::*;
 use super::voice_data::locale::VoiceLocale;
 use super::voice_data::package::VoicePackage;
 
+fn parse_dotversion(path: &Path) -> Option<Version> {
+    std::fs::read(path)
+        .map(|version| {
+            if version.len() == 3 {
+                tracing::info!("Found old format version file");
+                Some(Version::new(version[0], version[1], version[2]))
+            }
+            else if version.len() > 3 {
+                String::from_utf8(version)
+                    .map(|version_str| Version::from_str(&version_str))
+                    .ok()
+                    .flatten()
+            }
+            else {
+                tracing::error!(?path, "The `.version` file is too short!");
+                None
+            }
+        })
+        .ok()
+        .flatten()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Game {
     path: PathBuf,
@@ -65,9 +87,8 @@ impl GameExt for Game {
             bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
         }
 
-        let stored_version = std::fs::read(self.path.join(".version"))
-            .map(|version| Version::new(version[0], version[1], version[2]))
-            .ok();
+        let stored_version_path = self.path.join(".version");
+        let stored_version = parse_dotversion(&stored_version_path);
 
         let file = File::open(
             self.path

--- a/src/games/star_rail/version_diff.rs
+++ b/src/games/star_rail/version_diff.rs
@@ -308,7 +308,7 @@ impl VersionDiff {
                 .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         tracing::debug!(
@@ -354,7 +354,7 @@ impl VersionDiff {
                 .version_file_path()
                 .unwrap_or(path.as_ref().join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         tracing::debug!(

--- a/src/games/star_rail/voice_data/package.rs
+++ b/src/games/star_rail/voice_data/package.rs
@@ -322,9 +322,22 @@ impl VoicePackage {
             } => {
                 match std::fs::read(path.join(".version")) {
                     Ok(curr) => {
-                        tracing::debug!("Found .version file: {}.{}.{}", curr[0], curr[1], curr[2]);
+                        tracing::debug!("Found .version file");
+                        if curr.len() == 3 {
+                            tracing::info!("Found old format version file");
+                            let parsed_ver = Version::new(curr[0], curr[1], curr[2]);
+                            Ok(parsed_ver)
+                        }
+                        else if curr.len() > 3 {
+                            let version_str = String::from_utf8(curr)?;
 
-                        Ok(Version::new(curr[0], curr[1], curr[2]))
+                            Version::from_str(&version_str).ok_or_else(|| {
+                                anyhow::anyhow!("Invalid version string: {version_str}")
+                            })
+                        }
+                        else {
+                            Err(anyhow::anyhow!("The `.version` file is too short"))
+                        }
                     }
 
                     // We don't create .version file here because we don't actually know current

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use crate::version::Version;
 use crate::traits::prelude::*;
-
 use super::api;
 use super::consts::*;
 use super::version_diff::*;
@@ -57,7 +56,11 @@ impl GameExt for Game {
             .map(|version| Version::new(version[0], version[1], version[2]))
             .ok();
 
-        let file = File::open(self.path.join(self.edition.data_folder()).join("globalgamemanagers"))?;
+        let file = File::open(
+            self.path
+                .join(self.edition.data_folder())
+                .join("globalgamemanagers")
+        )?;
 
         let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
         let mut version_ptr: usize = 0;
@@ -66,7 +69,11 @@ impl GameExt for Game {
         for byte in file.bytes().skip(4000).take(10000).flatten() {
             match byte {
                 0 => {
-                    if correct && !version[0].is_empty() && !version[1].is_empty() && !version[2].is_empty() {
+                    if correct
+                        && !version[0].is_empty()
+                        && !version[1].is_empty()
+                        && !version[2].is_empty()
+                    {
                         let found_version = Version::new(
                             bytes_to_num(&version[0]),
                             bytes_to_num(&version[1]),
@@ -102,7 +109,6 @@ impl GameExt for Game {
                     if correct && b"0123456789".contains(&byte) {
                         version[version_ptr].push(byte);
                     }
-
                     else {
                         correct = false;
                     }
@@ -132,13 +138,22 @@ impl Game {
                 Ok(version) => version,
                 Err(err) => {
                     if self.path.exists() && self.path.metadata()?.len() == 0 {
-                        let downloaded_size = response.main.major.game_pkgs.iter()
+                        let downloaded_size = response
+                            .main
+                            .major
+                            .game_pkgs
+                            .iter()
                             .flat_map(|pkg| pkg.size.parse::<u64>())
                             .sum();
 
-                        let unpacked_size = response.main.major.game_pkgs.iter()
+                        let unpacked_size = response
+                            .main
+                            .major
+                            .game_pkgs
+                            .iter()
                             .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                            .sum::<u64>() - downloaded_size;
+                            .sum::<u64>()
+                            - downloaded_size;
 
                         return Ok(VersionDiff::NotInstalled {
                             latest: Version::from_str(&response.main.major.version).unwrap(),
@@ -148,7 +163,11 @@ impl Game {
                             downloaded_size,
                             unpacked_size,
 
-                            segments_uris: response.main.major.game_pkgs.into_iter()
+                            segments_uris: response
+                                .main
+                                .major
+                                .game_pkgs
+                                .into_iter()
                                 .map(|segment| segment.url)
                                 .collect(),
 
@@ -174,19 +193,25 @@ impl Game {
                     if let Some(predownload_major) = predownload_info.major {
                         for diff in predownload_info.patches {
                             if diff.version == current {
-                                let downloaded_size = diff.game_pkgs.iter()
+                                let downloaded_size = diff
+                                    .game_pkgs
+                                    .iter()
                                     .flat_map(|pkg| pkg.size.parse::<u64>())
                                     .sum();
 
-                                let unpacked_size = diff.game_pkgs.iter()
+                                let unpacked_size = diff
+                                    .game_pkgs
+                                    .iter()
                                     .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                                    .sum::<u64>() - downloaded_size;
+                                    .sum::<u64>()
+                                    - downloaded_size;
 
                                 return Ok(VersionDiff::Predownload {
                                     current,
                                     latest: Version::from_str(predownload_major.version).unwrap(),
 
-                                    uri: diff.game_pkgs[0].url.clone(), // TODO: can be a hard issue in future
+                                    uri: diff.game_pkgs[0].url.clone(), /* TODO: can be a hard
+                                                                         * issue in future */
                                     edition: self.edition,
 
                                     downloaded_size,
@@ -206,25 +231,34 @@ impl Game {
                     edition: self.edition
                 })
             }
-
             else {
-                tracing::debug!("Game is outdated: {} -> {}", current, response.main.major.version);
+                tracing::debug!(
+                    "Game is outdated: {} -> {}",
+                    current,
+                    response.main.major.version
+                );
 
                 for diff in response.main.patches {
                     if diff.version == current {
-                        let downloaded_size = diff.game_pkgs.iter()
+                        let downloaded_size = diff
+                            .game_pkgs
+                            .iter()
                             .flat_map(|pkg| pkg.size.parse::<u64>())
                             .sum();
 
-                        let unpacked_size = diff.game_pkgs.iter()
+                        let unpacked_size = diff
+                            .game_pkgs
+                            .iter()
                             .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                            .sum::<u64>() - downloaded_size;
+                            .sum::<u64>()
+                            - downloaded_size;
 
                         return Ok(VersionDiff::Diff {
                             current,
                             latest: Version::from_str(response.main.major.version).unwrap(),
 
-                            uri: diff.game_pkgs[0].url.clone(), // TODO: can be a hard issue in future
+                            uri: diff.game_pkgs[0].url.clone(), /* TODO: can be a hard issue in
+                                                                 * future */
                             edition: self.edition,
 
                             downloaded_size,
@@ -244,17 +278,25 @@ impl Game {
                 })
             }
         }
-
         else {
             tracing::debug!("Game is not installed");
 
-            let downloaded_size = response.main.major.game_pkgs.iter()
+            let downloaded_size = response
+                .main
+                .major
+                .game_pkgs
+                .iter()
                 .flat_map(|pkg| pkg.size.parse::<u64>())
                 .sum();
 
-            let unpacked_size = response.main.major.game_pkgs.iter()
+            let unpacked_size = response
+                .main
+                .major
+                .game_pkgs
+                .iter()
                 .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                .sum::<u64>() - downloaded_size;
+                .sum::<u64>()
+                - downloaded_size;
 
             Ok(VersionDiff::NotInstalled {
                 latest: Version::from_str(&response.main.major.version).unwrap(),
@@ -264,7 +306,11 @@ impl Game {
                 downloaded_size,
                 unpacked_size,
 
-                segments_uris: response.main.major.game_pkgs.into_iter()
+                segments_uris: response
+                    .main
+                    .major
+                    .game_pkgs
+                    .into_iter()
                     .map(|segment| segment.url)
                     .collect(),
 

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -8,6 +8,28 @@ use super::api;
 use super::consts::*;
 use super::version_diff::*;
 
+fn parse_dotversion(path: &Path) -> Option<Version> {
+    std::fs::read(path)
+        .map(|version| {
+            if version.len() == 3 {
+                tracing::info!("Found old format version file");
+                Some(Version::new(version[0], version[1], version[2]))
+            }
+            else if version.len() > 3 {
+                String::from_utf8(version)
+                    .map(|version_str| Version::from_str(&version_str))
+                    .ok()
+                    .flatten()
+            }
+            else {
+                tracing::error!(?path, "The `.version` file is too short!");
+                None
+            }
+        })
+        .ok()
+        .flatten()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Game {
     path: PathBuf,
@@ -52,9 +74,8 @@ impl GameExt for Game {
             bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
         }
 
-        let stored_version = std::fs::read(self.path.join(".version"))
-            .map(|version| Version::new(version[0], version[1], version[2]))
-            .ok();
+        let stored_version_path = self.path.join(".version");
+        let stored_version = parse_dotversion(&stored_version_path);
 
         let file = File::open(
             self.path

--- a/src/games/zzz/version_diff.rs
+++ b/src/games/zzz/version_diff.rs
@@ -1,23 +1,21 @@
 use std::path::{Path, PathBuf};
 use std::os::unix::prelude::PermissionsExt;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::consts::GameEdition;
-
 use crate::version::Version;
 use crate::traits::version_diff::VersionDiffExt;
-
 #[cfg(feature = "install")]
 use crate::{
+    external::hpatchz,
     installer::{
+        archives::Archive,
         downloader::{Downloader, DownloadingError},
-        installer::Update as InstallerUpdate,
         free_space,
-        archives::Archive
-    },
-    external::hpatchz
+        installer::Update as InstallerUpdate
+    }
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -99,9 +97,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
-        /// 
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -122,9 +122,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
-        /// 
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -150,9 +152,11 @@ pub enum VersionDiff {
         downloaded_size: u64,
         unpacked_size: u64,
 
-        /// Path to the folder this difference should be installed by the `install` method
-        /// 
-        /// This value can be `None`, so `install` will return `Err(DiffDownloadError::PathNotSpecified)`
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
         installation_path: Option<PathBuf>,
 
         /// Optional path to the `.version` file
@@ -168,29 +172,49 @@ impl VersionDiff {
     pub fn version_file_path(&self) -> Option<PathBuf> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { version_file_path, .. } |
-            Self::Diff { version_file_path, .. } |
-            Self::NotInstalled { version_file_path, .. } => version_file_path.to_owned()
+            Self::Predownload {
+                version_file_path, ..
+            }
+            | Self::Diff {
+                version_file_path, ..
+            }
+            | Self::NotInstalled {
+                version_file_path, ..
+            } => version_file_path.to_owned()
         }
     }
 
     /// Return currently selected temp folder path
-    /// 
+    ///
     /// Default is `std::env::temp_dir()` value
     pub fn temp_folder(&self) -> PathBuf {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => std::env::temp_dir(),
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => std::env::temp_dir(),
 
             // Can be installed
-            Self::Predownload { temp_folder, .. } |
-            Self::Diff { temp_folder, .. } |
-            Self::NotInstalled { temp_folder, .. } => match temp_folder {
+            Self::Predownload {
+                temp_folder, ..
+            }
+            | Self::Diff {
+                temp_folder, ..
+            }
+            | Self::NotInstalled {
+                temp_folder, ..
+            } => match temp_folder {
                 Some(path) => path.to_owned(),
                 None => std::env::temp_dir()
             }
@@ -200,23 +224,33 @@ impl VersionDiff {
     pub fn with_temp_folder(mut self, temp: PathBuf) -> Self {
         match &mut self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => self,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => self,
 
             // Can be installed
-            Self::Predownload { temp_folder, .. } => {
+            Self::Predownload {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
             }
 
-            Self::Diff { temp_folder, .. } => {
+            Self::Diff {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
             }
 
-            Self::NotInstalled { temp_folder, .. } => {
+            Self::NotInstalled {
+                temp_folder, ..
+            } => {
                 *temp_folder = Some(temp);
 
                 self
@@ -226,77 +260,137 @@ impl VersionDiff {
 }
 
 impl VersionDiffExt for VersionDiff {
+    type Edition = GameEdition;
     type Error = DiffDownloadingError;
     type Update = DiffUpdate;
-    type Edition = GameEdition;
 
     fn edition(&self) -> GameEdition {
         match self {
-            Self::Latest { edition, .. } |
-            Self::Predownload { edition, .. } |
-            Self::Diff { edition, .. } |
-            Self::Outdated { edition, .. } |
-            Self::NotInstalled { edition, .. } => *edition
+            Self::Latest {
+                edition, ..
+            }
+            | Self::Predownload {
+                edition, ..
+            }
+            | Self::Diff {
+                edition, ..
+            }
+            | Self::Outdated {
+                edition, ..
+            }
+            | Self::NotInstalled {
+                edition, ..
+            } => *edition
         }
     }
 
     fn current(&self) -> Option<Version> {
         match self {
-            Self::Latest { version: current, .. } |
-            Self::Predownload { current, .. } |
-            Self::Diff { current, .. } |
-            Self::Outdated { current, .. } => Some(*current),
+            Self::Latest {
+                version: current, ..
+            }
+            | Self::Predownload {
+                current, ..
+            }
+            | Self::Diff {
+                current, ..
+            }
+            | Self::Outdated {
+                current, ..
+            } => Some(*current),
 
-            Self::NotInstalled { .. } => None
+            Self::NotInstalled {
+                ..
+            } => None
         }
     }
 
     fn latest(&self) -> Version {
         match self {
-            Self::Latest { version: latest, .. } |
-            Self::Predownload { latest, .. } |
-            Self::Diff { latest, .. } |
-            Self::Outdated { latest, .. } |
-            Self::NotInstalled { latest, .. } => *latest
+            Self::Latest {
+                version: latest, ..
+            }
+            | Self::Predownload {
+                latest, ..
+            }
+            | Self::Diff {
+                latest, ..
+            }
+            | Self::Outdated {
+                latest, ..
+            }
+            | Self::NotInstalled {
+                latest, ..
+            } => *latest
         }
     }
 
     fn downloaded_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { downloaded_size, .. } |
-            Self::Diff { downloaded_size, .. } |
-            Self::NotInstalled { downloaded_size, .. } => Some(*downloaded_size)
+            Self::Predownload {
+                downloaded_size, ..
+            }
+            | Self::Diff {
+                downloaded_size, ..
+            }
+            | Self::NotInstalled {
+                downloaded_size, ..
+            } => Some(*downloaded_size)
         }
     }
 
     fn unpacked_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { unpacked_size, .. } |
-            Self::Diff { unpacked_size, .. } |
-            Self::NotInstalled { unpacked_size, .. } => Some(*unpacked_size)
+            Self::Predownload {
+                unpacked_size, ..
+            }
+            | Self::Diff {
+                unpacked_size, ..
+            }
+            | Self::NotInstalled {
+                unpacked_size, ..
+            } => Some(*unpacked_size)
         }
     }
 
     fn installation_path(&self) -> Option<&Path> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { installation_path, .. } |
-            Self::Diff { installation_path, .. } |
-            Self::NotInstalled { installation_path, .. } => match installation_path {
+            Self::Predownload {
+                installation_path, ..
+            }
+            | Self::Diff {
+                installation_path, ..
+            }
+            | Self::NotInstalled {
+                installation_path, ..
+            } => match installation_path {
                 Some(path) => Some(path.as_path()),
                 None => None
             }
@@ -306,32 +400,56 @@ impl VersionDiffExt for VersionDiff {
     fn downloading_uri(&self) -> Option<String> {
         match self {
             // Can't be installed
-            Self::Latest { .. } |
-            Self::Outdated { .. } => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
-            Self::Predownload { uri, .. } |
-            Self::Diff { uri, .. } => Some(uri.to_owned()),
+            Self::Predownload {
+                uri, ..
+            }
+            | Self::Diff {
+                uri, ..
+            } => Some(uri.to_owned()),
 
             // Can be installed but amogus
-            Self::NotInstalled { .. } => None
+            Self::NotInstalled {
+                ..
+            } => None
         }
     }
 
-    fn download_as(&mut self, path: impl AsRef<Path>, progress: impl Fn(u64, u64) + Send + 'static) -> Result<(), Self::Error> {
+    fn download_as(
+        &mut self,
+        path: impl AsRef<Path>,
+        progress: impl Fn(u64, u64) + Send + 'static
+    ) -> Result<(), Self::Error> {
         tracing::debug!("Downloading version difference");
 
         let mut downloader = Downloader::new(match self {
             // Can't be downloaded
-            Self::Latest { .. } => return Err(Self::Error::AlreadyLatest),
-            Self::Outdated { .. } => return Err(Self::Error::Outdated),
+            Self::Latest {
+                ..
+            } => return Err(Self::Error::AlreadyLatest),
+            Self::Outdated {
+                ..
+            } => return Err(Self::Error::Outdated),
 
             // Can be downloaded
-            Self::Predownload { uri, .. } |
-            Self::Diff { uri, .. } => uri,
+            Self::Predownload {
+                uri, ..
+            }
+            | Self::Diff {
+                uri, ..
+            } => uri,
 
             // Can be installed but amogus
-            Self::NotInstalled { .. } => return Err(Self::Error::MultipleSegments)
+            Self::NotInstalled {
+                ..
+            } => return Err(Self::Error::MultipleSegments)
         })?;
 
         if let Err(err) = downloader.download(path.as_ref(), progress) {
@@ -343,31 +461,51 @@ impl VersionDiffExt for VersionDiff {
         Ok(())
     }
 
-    fn install_to(&self, path: impl AsRef<Path>, _thread_count: usize, updater: impl Fn(Self::Update) + Clone + Send + 'static) -> Result<(), Self::Error> {
+    fn install_to(
+        &self,
+        path: impl AsRef<Path>,
+        _thread_count: usize,
+        updater: impl Fn(Self::Update) + Clone + Send + 'static
+    ) -> Result<(), Self::Error> {
         tracing::debug!("Installing version difference");
 
         let uris = match self {
             // Can't be installed
-            Self::Latest { .. } => return Err(Self::Error::AlreadyLatest),
-            Self::Outdated { .. } => return Err(Self::Error::Outdated),
+            Self::Latest {
+                ..
+            } => return Err(Self::Error::AlreadyLatest),
+            Self::Outdated {
+                ..
+            } => return Err(Self::Error::Outdated),
 
             // Can be installed
-            Self::Predownload { uri, .. } |
-            Self::Diff { uri, .. } => vec![uri.to_owned()],
+            Self::Predownload {
+                uri, ..
+            }
+            | Self::Diff {
+                uri, ..
+            } => vec![uri.to_owned()],
 
-            Self::NotInstalled { segments_uris, .. } => segments_uris.to_owned()
+            Self::NotInstalled {
+                segments_uris, ..
+            } => segments_uris.to_owned()
         };
 
         let path = path.as_ref().to_path_buf();
         let temp_folder = self.temp_folder();
 
-        let downloaded_size = self.downloaded_size().expect("Failed to retrieve downloaded size");
-        let unpacked_size = self.unpacked_size().expect("Failed to retrieve unpacked size");
+        let downloaded_size = self
+            .downloaded_size()
+            .expect("Failed to retrieve downloaded size");
+        let unpacked_size = self
+            .unpacked_size()
+            .expect("Failed to retrieve unpacked size");
 
         (updater)(DiffUpdate::CheckingFreeSpace(temp_folder.clone()));
 
         // Check available free space for archive itself
-        let Some(space) = free_space::available(&temp_folder) else {
+        let Some(space) = free_space::available(&temp_folder)
+        else {
             tracing::error!("Path is not mounted: {:?}", temp_folder);
 
             return Err(DownloadingError::PathNotMounted(temp_folder).into());
@@ -376,12 +514,15 @@ impl VersionDiffExt for VersionDiff {
         // We can possibly store downloaded archive + unpacked data on the same disk
         let required = if free_space::is_same_disk(&temp_folder, &path) {
             downloaded_size + unpacked_size
-        } else {
+        }
+        else {
             downloaded_size
         };
 
         if space < required {
-            tracing::error!("No free space available in the temp folder. Required: {required}. Available: {space}");
+            tracing::error!(
+                "No free space available in the temp folder. Required: {required}. Available: {space}"
+            );
 
             return Err(DownloadingError::NoSpaceAvailable(temp_folder, required, space).into());
         }
@@ -389,7 +530,8 @@ impl VersionDiffExt for VersionDiff {
         (updater)(DiffUpdate::CheckingFreeSpace(path.clone()));
 
         // Check available free space for unpacked archive data
-        let Some(space) = free_space::available(&path) else {
+        let Some(space) = free_space::available(&path)
+        else {
             tracing::error!("Path is not mounted: {:?}", &path);
 
             return Err(DownloadingError::PathNotMounted(path.to_path_buf()).into());
@@ -398,21 +540,28 @@ impl VersionDiffExt for VersionDiff {
         // We can possibly store downloaded archive + unpacked data on the same disk
         let required = if free_space::is_same_disk(&path, &temp_folder) {
             unpacked_size + downloaded_size
-        } else {
+        }
+        else {
             unpacked_size
         };
 
         if space < required {
-            tracing::error!("No free space available in the installation folder. Required: {required}. Available: {space}");
+            tracing::error!(
+                "No free space available in the installation folder. Required: {required}. Available: {space}"
+            );
 
-            return Err(DownloadingError::NoSpaceAvailable(path.to_path_buf(), required, space).into());
+            return Err(
+                DownloadingError::NoSpaceAvailable(path.to_path_buf(), required, space).into()
+            );
         }
 
         let mut current_downloaded = 0;
         let mut segments_names = Vec::new();
 
         // Imitate Installer update message
-        (updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::DownloadingStarted(temp_folder.to_path_buf())));
+        (updater)(DiffUpdate::InstallerUpdate(
+            InstallerUpdate::DownloadingStarted(temp_folder.to_path_buf())
+        ));
 
         // Download segments
         for uri in uris {
@@ -427,10 +576,12 @@ impl VersionDiffExt for VersionDiff {
 
             // Download segment
             downloader.download(temp_folder.join(&segment_name), move |current, _| {
-                (installer_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::DownloadingProgress(
-                    current_downloaded + current,
-                    downloaded_size
-                )));
+                (installer_updater)(DiffUpdate::InstallerUpdate(
+                    InstallerUpdate::DownloadingProgress(
+                        current_downloaded + current,
+                        downloaded_size
+                    )
+                ));
             })?;
 
             segments_names.push(segment_name);
@@ -439,12 +590,16 @@ impl VersionDiffExt for VersionDiff {
         }
 
         // Report 100% download progress (just in case)
-        (updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::DownloadingProgress(downloaded_size, downloaded_size)));
+        (updater)(DiffUpdate::InstallerUpdate(
+            InstallerUpdate::DownloadingProgress(downloaded_size, downloaded_size)
+        ));
 
         let first_segment_name = segments_names[0].clone();
 
         // Imitate Installer update message
-        (updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::DownloadingFinished));
+        (updater)(DiffUpdate::InstallerUpdate(
+            InstallerUpdate::DownloadingFinished
+        ));
 
         // Extract downloaded segments
         // Ctrl+C / Ctrl+V from the Installer. Not a good approach,
@@ -453,7 +608,8 @@ impl VersionDiffExt for VersionDiff {
         match Archive::open(temp_folder.join(&first_segment_name)) {
             Ok(mut archive) => {
                 // Temporary workaround as we can't get archive extraction process
-                // directly - we'll spawn it in another thread and check this archive entries appearance in the filesystem
+                // directly - we'll spawn it in another thread and check this archive entries
+                // appearance in the filesystem
                 let mut total = 0;
 
                 let entries = archive
@@ -465,12 +621,17 @@ impl VersionDiffExt for VersionDiff {
 
                     let path = path.join(&entry.name);
 
-                    // Failed to change permissions => likely patch-related file and was made by the sudo, so root
+                    // Failed to change permissions => likely patch-related file and was made by the
+                    // sudo, so root
                     #[allow(unused_must_use)]
-                    if std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).is_err() {
-                        // For weird reason we can delete files made by root, but can't modify their permissions
-                        // We're not checking its result because if it's error - then it's either couldn't be removed (which is not the case)
-                        // or the file doesn't exist, which we obviously can just ignore
+                    if std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666))
+                        .is_err()
+                    {
+                        // For weird reason we can delete files made by root, but can't modify their
+                        // permissions We're not checking its result because
+                        // if it's error - then it's either couldn't be removed (which is not the
+                        // case) or the file doesn't exist, which we
+                        // obviously can just ignore
                         std::fs::remove_file(&path);
                     }
                 }
@@ -481,8 +642,15 @@ impl VersionDiffExt for VersionDiff {
                 let unpacking_updater = updater.clone();
 
                 let handle_2 = std::thread::spawn(move || {
-                    let mut entries = entries.into_iter()
-                        .map(|entry| (unpacking_path.join(&entry.name), entry.size.get_size(), true))
+                    let mut entries = entries
+                        .into_iter()
+                        .map(|entry| {
+                            (
+                                unpacking_path.join(&entry.name),
+                                entry.size.get_size(),
+                                true
+                            )
+                        })
                         .collect::<Vec<_>>();
 
                     let mut unpacked = 0;
@@ -504,7 +672,9 @@ impl VersionDiffExt for VersionDiff {
                             }
                         }
 
-                        (unpacking_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingProgress(unpacked, total)));
+                        (unpacking_updater)(DiffUpdate::InstallerUpdate(
+                            InstallerUpdate::UnpackingProgress(unpacked, total)
+                        ));
 
                         if empty {
                             break;
@@ -517,7 +687,9 @@ impl VersionDiffExt for VersionDiff {
 
                 // Run archive extraction in another thread to not to freeze the current one
                 let handle_1 = std::thread::spawn(move || {
-                    (unpacking_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingStarted(extract_to.clone())));
+                    (unpacking_updater)(DiffUpdate::InstallerUpdate(
+                        InstallerUpdate::UnpackingStarted(extract_to.clone())
+                    ));
 
                     // We have to create new instance of Archive here
                     // because otherwise it may not work after get_entries method call
@@ -525,19 +697,26 @@ impl VersionDiffExt for VersionDiff {
                         Ok(mut archive) => match archive.extract(&extract_to) {
                             Ok(_) => {
                                 // TODO error handling
-                                #[allow(unused_must_use)] {
+                                #[allow(unused_must_use)]
+                                {
                                     for name in segments_names {
                                         std::fs::remove_file(temp_folder.join(name));
                                     }
                                 }
 
-                                (unpacking_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingFinished));
+                                (unpacking_updater)(DiffUpdate::InstallerUpdate(
+                                    InstallerUpdate::UnpackingFinished
+                                ));
                             }
 
-                            Err(err) => (unpacking_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingError(err.to_string())))
-                        }
+                            Err(err) => (unpacking_updater)(DiffUpdate::InstallerUpdate(
+                                InstallerUpdate::UnpackingError(err.to_string())
+                            ))
+                        },
 
-                        Err(err) => (unpacking_updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingError(err.to_string())))
+                        Err(err) => (unpacking_updater)(DiffUpdate::InstallerUpdate(
+                            InstallerUpdate::UnpackingError(err.to_string())
+                        ))
                     }
                 });
 
@@ -545,24 +724,29 @@ impl VersionDiffExt for VersionDiff {
                 handle_2.join().unwrap();
             }
 
-            Err(err) => (updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingError(err.to_string())))
+            Err(err) => (updater)(DiffUpdate::InstallerUpdate(
+                InstallerUpdate::UnpackingError(err.to_string())
+            ))
         }
 
         // Imitate Installer update message
-        (updater)(DiffUpdate::InstallerUpdate(InstallerUpdate::UnpackingFinished));
+        (updater)(DiffUpdate::InstallerUpdate(
+            InstallerUpdate::UnpackingFinished
+        ));
 
         // Create `.version` file here even if hdiff patching is failed because
         // it's easier to explain user why he should run files repairer than
         // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)] {
-            let version_path = self.version_file_path()
-                .unwrap_or(path.join(".version"));
+        #[allow(unused_must_use)]
+        {
+            let version_path = self.version_file_path().unwrap_or(path.join(".version"));
 
             std::fs::write(version_path, self.latest().version);
         }
 
         // Apply hdiff patches
-        // We're ignoring Err because in practice it means that hdifffiles.txt is missing
+        // We're ignoring Err because in practice it means that hdifffiles.txt is
+        // missing
         if let Ok(files) = std::fs::read_to_string(path.join("hdifffiles.txt")) {
             tracing::debug!("Applying hdiff patches");
 
@@ -571,7 +755,9 @@ impl VersionDiffExt for VersionDiff {
             let files = files.lines().collect::<Vec<&str>>();
             let hdiffs = files.len() as u64;
 
-            // {"remoteName": "AnimeGame_Data/StreamingAssets/Audio/GeneratedSoundBanks/Windows/Japanese/1001.pck"}
+            // {"remoteName":
+            // "AnimeGame_Data/StreamingAssets/Audio/GeneratedSoundBanks/Windows/Japanese/
+            // 1001.pck"}
             for (i, file) in files.into_iter().enumerate() {
                 let relative_file = &file[16..file.len() - 2];
 
@@ -586,7 +772,11 @@ impl VersionDiffExt for VersionDiff {
 
                     // If we were able to get API response - it shouldn't be impossible
                     // to also get integrity files list from the same API
-                    match super::repairer::try_get_integrity_file(self.edition(), relative_file, Some(*crate::REQUESTS_TIMEOUT)) {
+                    match super::repairer::try_get_integrity_file(
+                        self.edition(),
+                        relative_file,
+                        Some(*crate::REQUESTS_TIMEOUT)
+                    ) {
                         Ok(Some(integrity)) => {
                             if !integrity.fast_verify(&path) {
                                 if let Err(err) = integrity.repair(&path) {
@@ -600,21 +790,21 @@ impl VersionDiffExt for VersionDiff {
                         Ok(None) => {
                             tracing::error!("Failed to repair corrupted file: not found");
 
-                            return Err(Self::Error::HdiffPatch(err.to_string()))
+                            return Err(Self::Error::HdiffPatch(err.to_string()));
                         }
 
                         Err(repair_fail) => {
                             tracing::error!("Failed to repair corrupted file: {repair_fail}");
 
-                            return Err(Self::Error::HdiffPatch(err.to_string()))
+                            return Err(Self::Error::HdiffPatch(err.to_string()));
                         }
                     }
 
-                    #[allow(unused_must_use)] {
+                    #[allow(unused_must_use)]
+                    {
                         std::fs::remove_file(&patch);
                     }
                 }
-
                 // If patch was successfully applied
                 else {
                     // FIXME: handle errors properly
@@ -640,7 +830,8 @@ impl VersionDiffExt for VersionDiff {
         tracing::debug!("Deleting outdated files");
 
         // Remove outdated files
-        // We're ignoring Err because in practice it means that deletefiles.txt is missing
+        // We're ignoring Err because in practice it means that deletefiles.txt is
+        // missing
         if let Ok(files) = std::fs::read_to_string(path.join("deletefiles.txt")) {
             let files = files.lines().collect::<Vec<&str>>();
             let files_len = files.len() as u64;
@@ -654,7 +845,10 @@ impl VersionDiffExt for VersionDiff {
                 std::fs::remove_file(&file)
                     .expect(&format!("Failed to remove outdated file: {:?}", file));
 
-                (updater)(Self::Update::RemovingOutdatedProgress(i as u64 + 1, files_len));
+                (updater)(Self::Update::RemovingOutdatedProgress(
+                    i as u64 + 1,
+                    files_len
+                ));
             }
 
             std::fs::remove_file(path.join("deletefiles.txt"))

--- a/src/games/zzz/version_diff.rs
+++ b/src/games/zzz/version_diff.rs
@@ -741,7 +741,7 @@ impl VersionDiffExt for VersionDiff {
         {
             let version_path = self.version_file_path().unwrap_or(path.join(".version"));
 
-            std::fs::write(version_path, self.latest().version);
+            std::fs::write(version_path, self.latest().to_string());
         }
 
         // Apply hdiff patches

--- a/src/patches/jadeite/mod.rs
+++ b/src/patches/jadeite/mod.rs
@@ -22,9 +22,27 @@ pub fn is_installed(folder: impl AsRef<Path>) -> bool {
 }
 
 pub fn get_version(folder: impl AsRef<Path>) -> anyhow::Result<Version> {
-    let bytes = std::fs::read(folder.as_ref().join(".version"))?;
+    let dotversion_path = folder.as_ref().join(".version");
+    let version_bytes = std::fs::read(dotversion_path)?;
 
-    Ok(Version::new(bytes[0], bytes[1], bytes[2]))
+    if version_bytes.len() == 3 {
+        tracing::info!("Found old format version file");
+        Ok(Version::new(
+            version_bytes[0],
+            version_bytes[1],
+            version_bytes[2]
+        ))
+    }
+    else if version_bytes.len() > 3 {
+        let version_str = String::from_utf8(version_bytes)?;
+        Version::from_str(&version_str)
+            .ok_or_else(|| anyhow::anyhow!("Invalid version string: {version_str}"))
+    }
+    else {
+        Err(anyhow::anyhow!(
+            "The `.version` file is too short, cannot parse"
+        ))
+    }
 }
 
 #[cfg(feature = "install")]

--- a/src/patches/jadeite/mod.rs
+++ b/src/patches/jadeite/mod.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use crate::version::Version;
-
 #[cfg(feature = "install")]
 use crate::installer::installer::*;
 
@@ -13,7 +12,6 @@ pub const REPO_API_URI: &str = "https://codeberg.org/api/v1/repos/mkrsym1/jadeit
 pub const METADATA_URIS: &[&str] = &[
     // Primary
     "https://codeberg.org/mkrsym1/jadeite/raw/branch/master/metadata.json",
-
     // Mirrors
     "https://notabug.org/mkrsym1/jadeite-mirror/raw/master/metadata.json"
 ];
@@ -32,24 +30,30 @@ pub fn get_version(folder: impl AsRef<Path>) -> anyhow::Result<Version> {
 #[cfg(feature = "install")]
 #[cached::proc_macro::cached(result)]
 pub fn get_latest() -> anyhow::Result<JadeiteLatest> {
-    let response = minreq::get(REPO_API_URI).send()?.json::<serde_json::Value>()?;
+    let response = minreq::get(REPO_API_URI)
+        .send()?
+        .json::<serde_json::Value>()?;
 
-    let version = response.get("tag_name")
+    let version = response
+        .get("tag_name")
         .and_then(|tag| tag.as_str())
         .map(|tag| tag.strip_prefix('v').unwrap_or(tag))
         .and_then(Version::from_str);
 
-    let Some(version) = version else {
+    let Some(version) = version
+    else {
         anyhow::bail!("Failed to request latest patch version");
     };
 
-    let download_uri = response.get("assets")
+    let download_uri = response
+        .get("assets")
         .and_then(|assets| assets.as_array())
         .and_then(|assets| assets.first())
         .and_then(|asset| asset.get("browser_download_url"))
         .and_then(|url| url.as_str());
 
-    let Some(download_uri) = download_uri else {
+    let Some(download_uri) = download_uri
+    else {
         anyhow::bail!("Failed to request patch downloading URI");
     };
 
@@ -63,12 +67,14 @@ pub fn get_latest() -> anyhow::Result<JadeiteLatest> {
 #[cached::proc_macro::cached(result)]
 pub fn get_metadata() -> anyhow::Result<metadata::JadeiteMetadata> {
     for uri in METADATA_URIS {
-        let Ok(resp) = minreq::get(*uri).with_timeout(20).send() else {
+        let Ok(resp) = minreq::get(*uri).with_timeout(20).send()
+        else {
             tracing::warn!("Could not reach '{uri}'. Attempting to use next fallback");
             continue;
         };
 
-        let Ok(json) = resp.json::<serde_json::Value>() else {
+        let Ok(json) = resp.json::<serde_json::Value>()
+        else {
             tracing::warn!("Got invalid response from '{uri}'. Attempting to use next fallback");
             continue;
         };
@@ -87,7 +93,11 @@ pub struct JadeiteLatest {
 
 impl JadeiteLatest {
     #[cfg(feature = "install")]
-    pub fn install(&self, folder: impl AsRef<Path>, updater: impl Fn(Update) + Clone + Send + 'static) -> anyhow::Result<()> {
+    pub fn install(
+        &self,
+        folder: impl AsRef<Path>,
+        updater: impl Fn(Update) + Clone + Send + 'static
+    ) -> anyhow::Result<()> {
         Installer::new(&self.download_uri)?
             .with_filename("jadeite.zip")
             .with_free_space_check(false)


### PR DESCRIPTION
Changes the `.version` file format to prevent confusion when doing an "import game" process from the wiki. There have been multiple users who got ridiculous version numbers that then fail to update due to the ascii numbers being bigger than the version.

Compatible with the current installs (accepts the three-byte format) and should eventually convert into the ascii format.

From the commit message,
## Pros:
- Easier to edit with a text editor
- Simpler user instructions, less confusion for "game import" case

## Cons:
- 2 more bytes used on disk
- String parsing instead of just copying the bytes from a file

#### Necessary additional changes
- Launchers that have the "import game" change merged need to change the way the version is written
- Needs wiki updates