### PR TITLE
Fix free_space.rs not handling multiple symlinks or relative paths.

### DIFF
--- a/src/installer/free_space.rs
+++ b/src/installer/free_space.rs
@@ -1,3 +1,4 @@
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use sysinfo::Disks;
@@ -8,21 +9,14 @@ use sysinfo::Disks;
 ///
 /// Can return `None` if path is not prefixed by any available disk
 pub fn available(path: impl AsRef<Path>) -> Option<u64> {
-    let mut disks = Disks::new_with_refreshed_list();
+    let disks = Disks::new_with_refreshed_list();
 
-    disks.sort_by(|a, b| {
-        let a = a.mount_point().as_os_str().len();
-        let b = b.mount_point().as_os_str().len();
-
-        a.cmp(&b).reverse()
-    });
-
-    let path = path.as_ref()
-        .read_link()
-        .unwrap_or_else(|_| path.as_ref().to_path_buf());
+    let path = path.as_ref().metadata().expect("Path does not exist");
+    let devno = path.dev();
 
     for disk in disks.iter() {
-        if path.starts_with(disk.mount_point()) {
+        let disk_meta = disk.mount_point().metadata();
+        if disk_meta.is_ok_and(|m| { m.dev() == devno }) {
             return Some(disk.available_space());
         }
     }
@@ -30,8 +24,25 @@ pub fn available(path: impl AsRef<Path>) -> Option<u64> {
     None
 }
 
-/// Check if two paths exist on the same disk
+/// Check if two paths are contained on the same device
 pub fn is_same_disk(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
+
+    let dev1 = path1.as_ref().metadata()
+        .expect("Path does not exist")
+        .dev();
+
+    let dev2 = path2.as_ref().metadata()
+        .expect("Path does not exist")
+        .dev();
+
+    // The semantics here aren't exactly the same as the old code (is_same_mount):
+    // This tests if the path are on the same device specifically,
+    // not that the mount point is the same.
+    dev1 == dev2
+}
+
+/// Check if two paths share the same mount point
+pub fn is_same_mount(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
     let mut disks = Disks::new_with_refreshed_list();
 
     disks.sort_by(|a, b| {

--- a/src/installer/free_space.rs
+++ b/src/installer/free_space.rs
@@ -11,12 +11,12 @@ use sysinfo::Disks;
 pub fn available(path: impl AsRef<Path>) -> Option<u64> {
     let disks = Disks::new_with_refreshed_list();
 
-    let path = path.as_ref().metadata().expect("Path does not exist");
-    let devno = path.dev();
+    let meta = path.as_ref().metadata().ok()?;
+    let devno = meta.dev();
 
     for disk in disks.iter() {
         let disk_meta = disk.mount_point().metadata();
-        if disk_meta.is_ok_and(|m| { m.dev() == devno }) {
+        if disk_meta.is_ok_and(|m| m.dev() == devno) {
             return Some(disk.available_space());
         }
     }
@@ -27,18 +27,13 @@ pub fn available(path: impl AsRef<Path>) -> Option<u64> {
 /// Check if two paths are contained on the same device
 pub fn is_same_disk(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
 
-    let dev1 = path1.as_ref().metadata()
-        .expect("Path does not exist")
-        .dev();
-
-    let dev2 = path2.as_ref().metadata()
-        .expect("Path does not exist")
-        .dev();
+    let Some(dev1) = path1.as_ref().metadata().ok() else { return false };
+    let Some(dev2) = path2.as_ref().metadata().ok() else { return false };
 
     // The semantics here aren't exactly the same as the old code (is_same_mount):
     // This tests if the path are on the same device specifically,
     // not that the mount point is the same.
-    dev1 == dev2
+    dev1.dev() == dev2.dev()
 }
 
 /// Check if two paths share the same mount point


### PR DESCRIPTION
The previous implementation of `available` and `is_same_disk` in `free_space.rs` determine the containing device by comparing the path's prefix to the device's mount point.

This is an issue when dealing with links or relative paths (such as when using the `LAUNCHER_FOLDER` env var). The previous implementation used `read_link` to de-reference the link once, but that doesn't work when multiple links are involved (although `canonicalize` would have worked in either case). Additionally `is_same_disk` would fail for different mount points for the same disk.

The new implementation uses the device numbers instead, which is the proper way to determine if two files are on the same device (see [`stat(2)`](https://linux.die.net/man/2/stat)).

I left the old version of `is_same_disk` in the function `is_same_mount`, in case there is a need for it.