### PR TITLE
Fix free_space::available being unable to check if the path does not (yet) exist

### DIFF
--- a/src/installer/free_space.rs
+++ b/src/installer/free_space.rs
@@ -26,9 +26,14 @@ pub fn available(path: impl AsRef<Path>) -> Option<u64> {
 
 /// Check if two paths are contained on the same device
 pub fn is_same_disk(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
-
-    let Some(dev1) = path1.as_ref().metadata().ok() else { return false };
-    let Some(dev2) = path2.as_ref().metadata().ok() else { return false };
+    let Some(dev1) = path1.as_ref().metadata().ok()
+    else {
+        return false;
+    };
+    let Some(dev2) = path2.as_ref().metadata().ok()
+    else {
+        return false;
+    };
 
     // The semantics here aren't exactly the same as the old code (is_same_mount):
     // This tests if the path are on the same device specifically,
@@ -47,11 +52,13 @@ pub fn is_same_mount(path1: impl AsRef<Path>, path2: impl AsRef<Path>) -> bool {
         a.cmp(&b).reverse()
     });
 
-    let path1 = path1.as_ref()
+    let path1 = path1
+        .as_ref()
         .read_link()
         .unwrap_or_else(|_| path1.as_ref().to_path_buf());
 
-    let path2 = path2.as_ref()
+    let path2 = path2
+        .as_ref()
         .read_link()
         .unwrap_or_else(|_| path2.as_ref().to_path_buf());
 

--- a/src/installer/free_space.rs
+++ b/src/installer/free_space.rs
@@ -11,7 +11,14 @@ use sysinfo::Disks;
 pub fn available(path: impl AsRef<Path>) -> Option<u64> {
     let disks = Disks::new_with_refreshed_list();
 
-    let meta = path.as_ref().metadata().ok()?;
+    let Some(meta) = path
+        .as_ref()
+        .ancestors()
+        .find_map(|parent_path| parent_path.metadata().ok())
+    else {
+        tracing::error!(path = ?path.as_ref(), "Could not find metadata for any of the ancestors of the path");
+        return None;
+    };
     let devno = meta.dev();
 
     for disk in disks.iter() {


### PR DESCRIPTION
Bug introduced: #48 
Bug reported: https://github.com/an-anime-team/an-anime-game-launcher/issues/652
Test methodology: start with clean launcher folder, try downloading wine during first setup.

Fix is to use https://doc.rust-lang.org/std/path/struct.Path.html#method.ancestors which checks the path itself and its ancestors (based on path components).