### PR TITLE
Overhaul game version detection

### DIFF
--- a/src/games/genshin/consts.rs
+++ b/src/games/genshin/consts.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::voice_data::locale::VoiceLocale;
 
@@ -9,7 +9,7 @@ impl From<GameEdition> for sophon::GameEdition {
     fn from(value: GameEdition) -> Self {
         match value {
             GameEdition::Global => sophon::GameEdition::Global,
-            GameEdition::China => sophon::GameEdition::China,
+            GameEdition::China => sophon::GameEdition::China
         }
     }
 }
@@ -19,7 +19,7 @@ impl From<&GameEdition> for sophon::GameEdition {
     fn from(value: &GameEdition) -> Self {
         match value {
             GameEdition::Global => sophon::GameEdition::Global,
-            GameEdition::China => sophon::GameEdition::China,
+            GameEdition::China => sophon::GameEdition::China
         }
     }
 }
@@ -44,6 +44,7 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
     pub fn api_uri(&self) -> &str {
         match self {
             GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=VYTpXlbWo8"),
@@ -52,10 +53,28 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
+    pub fn game_scan_url(&self) -> &str {
+        match self {
+            GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=VYTpXlbWo8"),
+            GameEdition::China  => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=jGHBHlcOq1")
+        }
+    }
+
+    #[inline]
+    #[rustfmt::skip]
     pub fn data_folder(&self) -> &str {
         match self {
             GameEdition::Global => concat!("Ge", "nsh", "inIm", "pact_Data"),
             GameEdition::China  => concat!("Yu", "anS", "hen", "_Data")
+        }
+    }
+
+    #[inline]
+    pub fn exe_name(&self) -> &str {
+        match self {
+            GameEdition::Global => "GenshinImpact.exe",
+            GameEdition::China => "YuanShen.exe"
         }
     }
 
@@ -75,14 +94,16 @@ impl GameEdition {
 
     pub fn from_system_lang() -> Self {
         let locale = std::env::var("LC_ALL")
-            .unwrap_or_else(|_| std::env::var("LC_MESSAGES")
-            .unwrap_or_else(|_| std::env::var("LANG")
-            .unwrap_or(String::from("en_us"))))
+            .unwrap_or_else(|_| {
+                std::env::var("LC_MESSAGES")
+                    .unwrap_or_else(|_| std::env::var("LANG").unwrap_or(String::from("en_us")))
+            })
             .to_ascii_lowercase();
 
         if locale.starts_with("zh_cn") {
             Self::China
-        } else {
+        }
+        else {
             Self::Global
         }
     }
@@ -98,12 +119,17 @@ impl GameEdition {
 
 #[inline]
 pub fn get_voice_packages_path<T: AsRef<Path>>(game_path: T, game_edition: GameEdition) -> PathBuf {
-    game_path.as_ref()
+    game_path
+        .as_ref()
         .join(game_edition.data_folder())
         .join("StreamingAssets/AudioAssets")
 }
 
 #[inline]
-pub fn get_voice_package_path<T: AsRef<Path>>(game_path: T, game_edition: GameEdition, locale: VoiceLocale) -> PathBuf {
+pub fn get_voice_package_path<T: AsRef<Path>>(
+    game_path: T,
+    game_edition: GameEdition,
+    locale: VoiceLocale
+) -> PathBuf {
     get_voice_packages_path(game_path, game_edition).join(locale.to_folder())
 }

--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use crate::sophon;
@@ -12,26 +10,16 @@ use super::version_diff::*;
 use super::voice_data::locale::VoiceLocale;
 use super::voice_data::package::VoicePackage;
 
-fn parse_dotversion(path: &Path) -> Option<Version> {
-    std::fs::read(path)
-        .map(|version| {
-            if version.len() == 3 {
-                tracing::info!("Found old format version file");
-                Some(Version::new(version[0], version[1], version[2]))
-            }
-            else if version.len() > 3 {
-                String::from_utf8(version)
-                    .map(|version_str| Version::from_str(version_str.trim_end()))
-                    .ok()
-                    .flatten()
-            }
-            else {
-                tracing::error!(?path, "The `.version` file is too short!");
-                None
-            }
-        })
-        .ok()
-        .flatten()
+fn get_version_from_game_files(
+    file: &Path,
+    stored_version: &Option<Version>
+) -> anyhow::Result<Option<Version>> {
+    crate::version_detect::get_version_from_game_files::<4000, 10000>(
+        file,
+        stored_version,
+        0..=0u8,
+        b'_'..=b'_'
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,81 +73,51 @@ impl GameExt for Game {
     fn get_version(&self) -> anyhow::Result<Version> {
         tracing::debug!("Trying to get installed game version");
 
-        #[inline]
-        fn bytes_to_num(bytes: &[u8]) -> u8 {
-            bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
-        }
-
         let stored_version_path = self.path.join(".version");
-        let stored_version = parse_dotversion(&stored_version_path);
+        let stored_version = crate::version_detect::parse_dotversion(&stored_version_path);
 
-        let path = self
+        let version_detect_path = self
             .path
             .join(self.edition.data_folder())
             .join("globalgamemanagers");
 
-        let file = BufReader::new(File::open(path)?);
-
-        let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
-        let mut version_ptr: usize = 0;
-        let mut correct = true;
-
-        for byte in file.bytes().skip(4000).take(10000).flatten() {
-            match byte {
-                0 => {
-                    version = [vec![], vec![], vec![]];
-                    version_ptr = 0;
-                    correct = true;
-                }
-
-                b'.' => {
-                    version_ptr += 1;
-
-                    if version_ptr > 2 {
-                        correct = false;
-                    }
-                }
-
-                b'_' => {
-                    if correct
-                        && !version[0].is_empty()
-                        && !version[1].is_empty()
-                        && !version[2].is_empty()
-                    {
-                        let found_version = Version::new(
-                            bytes_to_num(&version[0]),
-                            bytes_to_num(&version[1]),
-                            bytes_to_num(&version[2])
-                        );
-
-                        // Little workaround for the minor game patch versions (notably 1.0.1)
-                        // Prioritize version stored in the .version file
-                        // because it's parsed from the API directly
-                        if let Some(stored_version) = stored_version {
-                            if stored_version > found_version {
-                                return Ok(stored_version);
-                            }
-                        }
-
-                        return Ok(found_version);
-                    }
-
-                    correct = false;
-                }
-
-                _ => {
-                    if correct && byte.is_ascii_digit() {
-                        version[version_ptr].push(byte);
-                    }
-                    else {
-                        correct = false;
-                    }
-                }
-            }
+        if let Some(version_from_files) =
+            get_version_from_game_files(&version_detect_path, &stored_version)?
+        {
+            tracing::info!(
+                version = version_from_files.to_string(),
+                "Found game version from game files"
+            );
+            return Ok(version_from_files);
         }
 
         if let Some(stored_version) = stored_version {
+            tracing::info!(version = stored_version.to_string(), "Found stored version");
             return Ok(stored_version);
+        }
+
+        if let Some(game_scan_version) = crate::version_detect::get_version_game_scan(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.game_scan_url(),
+            self.edition.game_id()
+        )? {
+            tracing::info!(
+                version = game_scan_version.to_string(),
+                "Found game version through game scan API"
+            );
+            return Ok(game_scan_version);
+        }
+
+        if let Some(sophon_version) = crate::version_detect::get_version_sophon(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.game_id(),
+            self.edition.into()
+        )? {
+            tracing::info!(
+                version = sophon_version.to_string(),
+                "Found game version through sophon API"
+            );
+            return Ok(sophon_version);
         }
 
         tracing::error!("Version's bytes sequence wasn't found");

--- a/src/games/honkai/consts.rs
+++ b/src/games/honkai/consts.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GameEdition {
@@ -31,6 +31,7 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
     pub fn api_uri(&self) -> &str {
         match self {
             GameEdition::China => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=jGHBHlcOq1"),
@@ -38,6 +39,16 @@ impl GameEdition {
         }
     }
 
+    #[inline]
+    #[rustfmt::skip]
+    pub fn game_scan_url(&self) -> &str {
+        match self {
+            GameEdition::China  => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=jGHBHlcOq1"),
+            _ => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=VYTpXlbWo8")
+        }
+    }
+
+    #[rustfmt::skip]
     pub fn api_game_id(&self) -> &str {
         // 5TIVvvcwtM  glb_official
         // g0mMIvshDb  jp_official
@@ -60,6 +71,11 @@ impl GameEdition {
     }
 
     #[inline]
+    pub fn exe_name(&self) -> &str {
+        "BH3.exe"
+    }
+
+    #[inline]
     pub fn telemetry_servers(&self) -> &[&str] {
         match self {
             Self::China => &[
@@ -78,27 +94,24 @@ impl GameEdition {
 
     pub fn from_system_lang() -> Self {
         let locale = std::env::var("LC_ALL")
-            .unwrap_or_else(|_| std::env::var("LC_MESSAGES")
-            .unwrap_or_else(|_| std::env::var("LANG")
-            .unwrap_or(String::from("en_us"))))
+            .unwrap_or_else(|_| {
+                std::env::var("LC_MESSAGES")
+                    .unwrap_or_else(|_| std::env::var("LANG").unwrap_or(String::from("en_us")))
+            })
             .to_ascii_lowercase();
 
         if locale.starts_with("zh_cn") {
             Self::China
         }
-
         else if locale.starts_with("zh_tw") {
             Self::Taiwan
         }
-
         else if locale.starts_with("ja") {
             Self::Japan
         }
-
         else if locale.starts_with("ko") {
             Self::Korea
         }
-
         else {
             Self::Global
         }

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -8,26 +8,16 @@ use super::api;
 use super::consts::*;
 use super::version_diff::*;
 
-fn parse_dotversion(path: &Path) -> Option<Version> {
-    std::fs::read(path)
-        .map(|version| {
-            if version.len() == 3 {
-                tracing::info!("Found old format version file");
-                Some(Version::new(version[0], version[1], version[2]))
-            }
-            else if version.len() > 3 {
-                String::from_utf8(version)
-                    .map(|version_str| Version::from_str(version_str.trim_end()))
-                    .ok()
-                    .flatten()
-            }
-            else {
-                tracing::error!(?path, "The `.version` file is too short!");
-                None
-            }
-        })
-        .ok()
-        .flatten()
+fn get_version_from_game_files(
+    file: &Path,
+    stored_version: &Option<Version>
+) -> anyhow::Result<Option<Version>> {
+    crate::version_detect::get_version_from_game_files::<4000, 10000>(
+        file,
+        stored_version,
+        0..=0u8,
+        0..=0u8
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,75 +60,38 @@ impl GameExt for Game {
     fn get_version(&self) -> anyhow::Result<Version> {
         tracing::debug!("Trying to get installed game version");
 
-        fn bytes_to_num(bytes: &[u8]) -> u8 {
-            bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
-        }
-
         let stored_version_path = self.path.join(".version");
-        let stored_version = parse_dotversion(&stored_version_path);
+        let stored_version = crate::version_detect::parse_dotversion(&stored_version_path);
 
-        let file = BufReader::new(File::open(
+        if let Some(version_from_files) = get_version_from_game_files(
             self.path
                 .join(self.edition.data_folder())
                 .join("globalgamemanagers")
-        )?);
-
-        let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
-        let mut version_ptr: usize = 0;
-        let mut correct = true;
-
-        for byte in file.bytes().skip(4000).take(10000).flatten() {
-            match byte {
-                0 => {
-                    if correct
-                        && version_ptr == 2
-                        && !version[0].is_empty()
-                        && !version[1].is_empty()
-                        && !version[2].is_empty()
-                    {
-                        let found_version = Version::new(
-                            bytes_to_num(&version[0]),
-                            bytes_to_num(&version[1]),
-                            bytes_to_num(&version[2])
-                        );
-
-                        // Prioritize version stored in the .version file
-                        // because it's parsed from the API directly
-                        if let Some(stored_version) = stored_version {
-                            if stored_version > found_version {
-                                return Ok(stored_version);
-                            }
-                        }
-
-                        return Ok(found_version);
-                    }
-
-                    version = [vec![], vec![], vec![]];
-                    version_ptr = 0;
-                    correct = true;
-                }
-
-                b'.' => {
-                    version_ptr += 1;
-
-                    if version_ptr > 2 {
-                        correct = false;
-                    }
-                }
-
-                _ => {
-                    if correct && byte.is_ascii_digit() {
-                        version[version_ptr].push(byte);
-                    }
-                    else {
-                        correct = false;
-                    }
-                }
-            }
+                .as_ref(),
+            &stored_version
+        )? {
+            tracing::info!(
+                version = version_from_files.to_string(),
+                "Found game version from game files"
+            );
+            return Ok(version_from_files);
         }
 
         if let Some(stored_version) = stored_version {
+            tracing::info!(version = stored_version.to_string(), "Found stored version");
             return Ok(stored_version);
+        }
+
+        if let Some(game_scan_version) = crate::version_detect::get_version_game_scan(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.game_scan_url(),
+            self.edition.api_game_id()
+        )? {
+            tracing::info!(
+                version = game_scan_version.to_string(),
+                "Found game version through game scan API"
+            );
+            return Ok(game_scan_version);
         }
 
         tracing::error!("Version's bytes sequence wasn't found");

--- a/src/games/star_rail/consts.rs
+++ b/src/games/star_rail/consts.rs
@@ -44,21 +44,20 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
     pub fn api_uri(&self) -> &str {
         match self {
-            GameEdition::Global => concat!(
-                "https://sg-hyp-api.",
-                "ho",
-                "yo",
-                "verse",
-                ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=VYTpXlbWo8"
-            ),
-            GameEdition::China => concat!(
-                "https://hyp-api.",
-                "mih",
-                "oyo",
-                ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=jGHBHlcOq1"
-            )
+            GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=VYTpXlbWo8"),
+            GameEdition::China => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=jGHBHlcOq1")
+        }
+    }
+
+    #[inline]
+    #[rustfmt::skip]
+    pub fn game_scan_url(&self) -> &str {
+        match self {
+            GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=VYTpXlbWo8"),
+            GameEdition::China  => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=jGHBHlcOq1")
         }
     }
 
@@ -66,6 +65,11 @@ impl GameEdition {
     pub fn data_folder(&self) -> &str {
         // Same data folder name for every region
         concat!("Sta", "rRai", "l_Data")
+    }
+
+    #[inline]
+    pub fn exe_name(&self) -> &str {
+        "StarRail.exe"
     }
 
     /// API IDs used by Sophon

--- a/src/games/star_rail/game.rs
+++ b/src/games/star_rail/game.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -14,26 +12,16 @@ use super::version_diff::*;
 use super::voice_data::locale::VoiceLocale;
 use super::voice_data::package::VoicePackage;
 
-fn parse_dotversion(path: &Path) -> Option<Version> {
-    std::fs::read(path)
-        .map(|version| {
-            if version.len() == 3 {
-                tracing::info!("Found old format version file");
-                Some(Version::new(version[0], version[1], version[2]))
-            }
-            else if version.len() > 3 {
-                String::from_utf8(version)
-                    .map(|version_str| Version::from_str(version_str.trim_end()))
-                    .ok()
-                    .flatten()
-            }
-            else {
-                tracing::error!(?path, "The `.version` file is too short!");
-                None
-            }
-        })
-        .ok()
-        .flatten()
+fn get_version_from_game_files(
+    file: &Path,
+    stored_version: &Option<Version>
+) -> anyhow::Result<Option<Version>> {
+    crate::version_detect::get_version_from_game_files::<2000, 10000>(
+        file,
+        stored_version,
+        0..=9u8,
+        0..=9u8
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,74 +71,50 @@ impl GameExt for Game {
     fn get_version(&self) -> anyhow::Result<Version> {
         tracing::debug!("Trying to get installed game version");
 
-        fn bytes_to_num(bytes: &[u8]) -> u8 {
-            bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
-        }
-
         let stored_version_path = self.path.join(".version");
-        let stored_version = parse_dotversion(&stored_version_path);
+        let stored_version = crate::version_detect::parse_dotversion(&stored_version_path);
 
-        let file = BufReader::new(File::open(
+        if let Some(version_from_files) = get_version_from_game_files(
             self.path
                 .join(self.edition.data_folder())
                 .join("data.unity3d")
-        )?);
-
-        let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
-        let mut version_ptr: usize = 0;
-        let mut correct = true;
-
-        for byte in file.bytes().skip(2000).take(10000).flatten() {
-            match byte {
-                0..10 => {
-                    if correct
-                        && !version[0].is_empty()
-                        && !version[1].is_empty()
-                        && !version[2].is_empty()
-                    {
-                        let found_version = Version::new(
-                            bytes_to_num(&version[0]),
-                            bytes_to_num(&version[1]),
-                            bytes_to_num(&version[2])
-                        );
-
-                        // Prioritize version stored in the .version file
-                        // because it's parsed from the API directly
-                        if let Some(stored_version) = stored_version {
-                            if stored_version > found_version {
-                                return Ok(stored_version);
-                            }
-                        }
-
-                        return Ok(found_version);
-                    }
-
-                    version = [vec![], vec![], vec![]];
-                    version_ptr = 0;
-                    correct = true;
-                }
-
-                b'.' => {
-                    version_ptr += 1;
-
-                    if version_ptr > 2 {
-                        correct = false;
-                    }
-                }
-
-                _ => {
-                    if correct && byte.is_ascii_digit() {
-                        version[version_ptr].push(byte);
-                    }
-                    else {
-                        correct = false;
-                    }
-                }
-            }
+                .as_ref(),
+            &stored_version
+        )? {
+            tracing::info!(
+                version = version_from_files.to_string(),
+                "Found game version from game files"
+            );
+            return Ok(version_from_files);
         }
 
         if let Some(stored_version) = stored_version {
+            tracing::info!(version = stored_version.to_string(), "Found stored version");
             return Ok(stored_version);
+        }
+
+        if let Some(game_scan_version) = crate::version_detect::get_version_game_scan(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.game_scan_url(),
+            self.edition.api_game_id()
+        )? {
+            tracing::info!(
+                version = game_scan_version.to_string(),
+                "Found game version through game scan API"
+            );
+            return Ok(game_scan_version);
+        }
+
+        if let Some(sophon_version) = crate::version_detect::get_version_sophon(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.api_game_id(),
+            self.edition.into()
+        )? {
+            tracing::info!(
+                version = sophon_version.to_string(),
+                "Found game version through sophon API"
+            );
+            return Ok(sophon_version);
         }
 
         tracing::error!("Version's bytes sequence wasn't found");

--- a/src/games/zzz/consts.rs
+++ b/src/games/zzz/consts.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GameEdition {
@@ -20,6 +20,7 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
     pub fn api_uri(&self) -> &str {
         match self {
             GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGamePackages?launcher_id=VYTpXlbWo8"),
@@ -28,8 +29,30 @@ impl GameEdition {
     }
 
     #[inline]
+    #[rustfmt::skip]
+    pub fn game_scan_url(&self) -> &str {
+        match self {
+            GameEdition::Global => concat!("https://sg-hyp-api.", "ho", "yo", "verse", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=VYTpXlbWo8"),
+            GameEdition::China  => concat!("https://hyp-api.", "mih", "oyo", ".com/hyp/hyp-connect/api/getGameScanInfo?launcher_id=jGHBHlcOq1")
+        }
+    }
+
+    #[inline]
     pub fn data_folder(&self) -> &str {
         concat!("Zen", "lessZ", "oneZero_Data")
+    }
+
+    #[inline]
+    pub fn exe_name(&self) -> &str {
+        "ZenlessZoneZero.exe"
+    }
+
+    #[inline]
+    pub fn api_game_id(&self) -> &str {
+        match self {
+            Self::Global => "U5hbdsT9W7",
+            Self::China => "x6znKlJ0xK"
+        }
     }
 
     #[inline]
@@ -52,14 +75,16 @@ impl GameEdition {
 
     pub fn from_system_lang() -> Self {
         let locale = std::env::var("LC_ALL")
-            .unwrap_or_else(|_| std::env::var("LC_MESSAGES")
-            .unwrap_or_else(|_| std::env::var("LANG")
-            .unwrap_or(String::from("en_us"))))
+            .unwrap_or_else(|_| {
+                std::env::var("LC_MESSAGES")
+                    .unwrap_or_else(|_| std::env::var("LANG").unwrap_or(String::from("en_us")))
+            })
             .to_ascii_lowercase();
 
         if locale.starts_with("zh_cn") {
             Self::China
-        } else {
+        }
+        else {
             Self::Global
         }
     }

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use crate::version::Version;
@@ -8,26 +6,16 @@ use super::api;
 use super::consts::*;
 use super::version_diff::*;
 
-fn parse_dotversion(path: &Path) -> Option<Version> {
-    std::fs::read(path)
-        .map(|version| {
-            if version.len() == 3 {
-                tracing::info!("Found old format version file");
-                Some(Version::new(version[0], version[1], version[2]))
-            }
-            else if version.len() > 3 {
-                String::from_utf8(version)
-                    .map(|version_str| Version::from_str(version_str.trim_end()))
-                    .ok()
-                    .flatten()
-            }
-            else {
-                tracing::error!(?path, "The `.version` file is too short!");
-                None
-            }
-        })
-        .ok()
-        .flatten()
+fn get_version_from_game_files(
+    file: &Path,
+    stored_version: &Option<Version>
+) -> anyhow::Result<Option<Version>> {
+    crate::version_detect::get_version_from_game_files::<45000, 10000>(
+        file,
+        stored_version,
+        0..=0u8,
+        0..=0u8
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,75 +58,38 @@ impl GameExt for Game {
     fn get_version(&self) -> anyhow::Result<Version> {
         tracing::debug!("Trying to get installed game version");
 
-        fn bytes_to_num(bytes: &[u8]) -> u8 {
-            bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
-        }
-
         let stored_version_path = self.path.join(".version");
-        let stored_version = parse_dotversion(&stored_version_path);
+        let stored_version = crate::version_detect::parse_dotversion(&stored_version_path);
 
-        let file = BufReader::new(File::open(
+        if let Some(version_from_files) = get_version_from_game_files(
             self.path
                 .join(self.edition.data_folder())
                 .join("globalgamemanagers")
-        )?);
-
-        let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
-        let mut version_ptr: usize = 0;
-        let mut correct = true;
-
-        for byte in file.bytes().skip(45000).take(10000).flatten() {
-            match byte {
-                0 => {
-                    if correct
-                        && !version[0].is_empty()
-                        && !version[1].is_empty()
-                        && !version[2].is_empty()
-                    {
-                        let found_version = Version::new(
-                            bytes_to_num(&version[0]),
-                            bytes_to_num(&version[1]),
-                            bytes_to_num(&version[2])
-                        );
-
-                        // Little workaround for the minor game patch versions (notably 1.0.1)
-                        // Prioritize version stored in the .version file
-                        // because it's parsed from the API directly
-                        if let Some(stored_version) = stored_version {
-                            if stored_version > found_version {
-                                return Ok(stored_version);
-                            }
-                        }
-
-                        return Ok(found_version);
-                    }
-
-                    version = [vec![], vec![], vec![]];
-                    version_ptr = 0;
-                    correct = true;
-                }
-
-                b'.' => {
-                    version_ptr += 1;
-
-                    if version_ptr > 2 {
-                        correct = false;
-                    }
-                }
-
-                _ => {
-                    if correct && byte.is_ascii_digit() {
-                        version[version_ptr].push(byte);
-                    }
-                    else {
-                        correct = false;
-                    }
-                }
-            }
+                .as_ref(),
+            &stored_version
+        )? {
+            tracing::info!(
+                version = version_from_files.to_string(),
+                "Found game version from game files"
+            );
+            return Ok(version_from_files);
         }
 
         if let Some(stored_version) = stored_version {
+            tracing::info!(version = stored_version.to_string(), "Found stored version");
             return Ok(stored_version);
+        }
+
+        if let Some(game_scan_version) = crate::version_detect::get_version_game_scan(
+            self.path.join(self.edition.exe_name()).as_ref(),
+            self.edition.game_scan_url(),
+            self.edition.api_game_id()
+        )? {
+            tracing::info!(
+                version = game_scan_version.to_string(),
+                "Found game version through game scan API"
+            );
+            return Ok(game_scan_version);
         }
 
         tracing::error!("Version's bytes sequence wasn't found");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ lazy_static::lazy_static! {
 }
 
 pub mod version;
+pub mod version_detect;
 pub mod traits;
 pub mod prettify_bytes;
 pub mod check_domain;

--- a/src/version_detect.rs
+++ b/src/version_detect.rs
@@ -1,0 +1,234 @@
+use std::ops::RangeInclusive;
+use std::fs::File;
+use std::io::{Read, Seek};
+use std::path::Path;
+
+use anyhow::Context;
+use md5::{Digest, Md5};
+
+use crate::version::Version;
+
+pub fn parse_dotversion(path: &Path) -> Option<Version> {
+    std::fs::read(path)
+        .map(|version| {
+            if version.len() == 3 {
+                tracing::info!("Found old format version file");
+                Some(Version::new(version[0], version[1], version[2]))
+            }
+            else if version.len() > 3 {
+                String::from_utf8(version)
+                    .map(|version_str| Version::from_str(version_str.trim_end()))
+                    .ok()
+                    .flatten()
+            }
+            else {
+                tracing::error!(?path, "The `.version` file is too short!");
+                None
+            }
+        })
+        .ok()
+        .flatten()
+}
+
+pub fn get_version_from_game_files<const OFFSET: u64, const REGION_SIZE: usize>(
+    file: &Path,
+    stored_version: &Option<Version>,
+    start_pattern: RangeInclusive<u8>,
+    end_pattern: RangeInclusive<u8>
+) -> anyhow::Result<Option<Version>> {
+    fn bytes_to_num(bytes: &[u8]) -> u8 {
+        bytes.iter().fold(0u8, |acc, &x| acc * 10 + (x - b'0'))
+    }
+
+    let mut file = File::open(file)?;
+    file.seek(std::io::SeekFrom::Start(OFFSET))?;
+    let mut search_region = [0u8; REGION_SIZE];
+    file.read_exact(&mut search_region)?;
+
+    let mut version: [Vec<u8>; 3] = [vec![], vec![], vec![]];
+    let mut version_ptr: usize = 0;
+    let mut correct = true;
+
+    for byte in search_region {
+        match byte {
+            x if end_pattern.contains(&x) => {
+                if correct
+                    && !version[0].is_empty()
+                    && !version[1].is_empty()
+                    && !version[2].is_empty()
+                {
+                    let found_version = Version::new(
+                        bytes_to_num(&version[0]),
+                        bytes_to_num(&version[1]),
+                        bytes_to_num(&version[2])
+                    );
+
+                    // Little workaround for the minor game patch versions (notably 1.0.1)
+                    // Prioritize version stored in the .version file
+                    // because it's parsed from the API directly
+                    if let Some(stored_version) = stored_version {
+                        if *stored_version > found_version {
+                            return Ok(Some(*stored_version));
+                        }
+                    }
+
+                    return Ok(Some(found_version));
+                }
+
+                correct = false;
+
+                if start_pattern.contains(&byte) {
+                    version = [vec![], vec![], vec![]];
+                    version_ptr = 0;
+                    correct = true;
+                }
+            }
+
+            x if start_pattern.contains(&x) => {
+                version = [vec![], vec![], vec![]];
+                version_ptr = 0;
+                correct = true;
+            }
+
+            b'.' => {
+                version_ptr += 1;
+
+                if version_ptr > 2 {
+                    correct = false;
+                }
+            }
+
+            _ => {
+                if correct && byte.is_ascii_digit() {
+                    version[version_ptr].push(byte);
+                }
+                else {
+                    correct = false;
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn get_version_game_scan(
+    exe_path: &Path,
+    scan_url: &str,
+    game_id: &str
+) -> anyhow::Result<Option<Version>> {
+    let exe_hash = format!("{:x}", Md5::digest(std::fs::read(exe_path)?));
+    let scan_info = minreq::get(scan_url)
+        .send()
+        .context("Sending game scan API request")?
+        .json::<serde_json::Value>()
+        .context("Parsing game scan API response")?;
+
+    Ok(scan_info
+        .get("data")
+        .and_then(|v| {
+            v.get("game_scan_info")?
+                .as_array()?
+                .iter()
+                .find_map(|scan_info| {
+                    if scan_info.get("game_id")?.as_str()? == game_id {
+                        scan_info.get("game_exe_list")?.as_array()
+                    }
+                    else {
+                        None
+                    }
+                })
+        })
+        .and_then(|exe_list| {
+            exe_list.iter().find_map(|exe_hash_item| {
+                if exe_hash_item
+                    .get("md5")?
+                    .as_str()?
+                    .eq_ignore_ascii_case(&exe_hash)
+                {
+                    exe_hash_item
+                        .get("version")?
+                        .as_str()
+                        .and_then(Version::from_str)
+                }
+                else {
+                    None
+                }
+            })
+        }))
+}
+
+#[cfg(feature = "sophon")]
+pub fn get_version_sophon(
+    exe_path: &Path,
+    game_id: &str,
+    edition: crate::sophon::GameEdition
+) -> anyhow::Result<Option<Version>> {
+    use crate::sophon;
+    let Some(exe_filename) = exe_path.file_name().and_then(|filename| filename.to_str())
+    else {
+        return Ok(None);
+    };
+    let exe_hash = format!("{:x}", Md5::digest(std::fs::read(exe_path)?));
+    let client = crate::reqwest::blocking::Client::new();
+
+    let game_branches = sophon::api::get_game_branches_info(&client, &edition)?;
+    let Some(package) = game_branches.get_package_by_id_or_biz_latest(game_id, false)
+    else {
+        tracing::warn!(game_id, ?edition, "No game branch found");
+        return Ok(None);
+    };
+
+    let download_info = sophon::api::get_game_download_sophon_info(&client, package, &edition)?;
+    let Some(dlinfo) = download_info.get_manifests_for("game")
+    else {
+        return Ok(None);
+    };
+
+    let download_manifest = sophon::api::get_download_manifest(&client, dlinfo)?;
+    let exe_hash_from_dl = download_manifest
+        .assets
+        .iter()
+        .find_map(|asset| (asset.asset_name == exe_filename).then_some(&asset.asset_hash_md5));
+
+    if let Some(dlhash) = exe_hash_from_dl {
+        if dlhash.eq_ignore_ascii_case(&exe_hash) {
+            return Ok(Version::from_str(&package.tag));
+        }
+    }
+    else {
+        tracing::error!("Failed to find exe hashes in sophon download api, asset not found")
+    }
+
+    // Hash does not match latest at this point, try to find in updates
+
+    let diffs = sophon::api::get_game_diffs_sophon_info(&client, package, &edition)?;
+    let Some(diff_info) = diffs.get_manifests_for("game")
+    else {
+        return Ok(None);
+    };
+
+    let patch_manifest = sophon::api::get_patch_manifest(&client, diff_info)?;
+    let Some(exe_hashes) = patch_manifest.patch_assets.iter().find_map(|patch_asset| {
+        (patch_asset.asset_name == exe_filename).then(|| {
+            patch_asset
+                .asset_patch_chunks
+                .iter()
+                .map(|(tag, chunk)| (tag, &chunk.original_file_md5))
+        })
+    })
+    else {
+        tracing::error!("Failed to get exe hashes from sophon update api, asset not found");
+        return Ok(None);
+    };
+
+    for (tag, patch_exe_hash) in exe_hashes {
+        if patch_exe_hash.eq_ignore_ascii_case(&exe_hash) {
+            return Ok(Version::from_str(tag));
+        }
+    }
+
+    tracing::warn!("Sophon API lookup faield to find any matching exe hash");
+
+    Ok(None)
+}


### PR DESCRIPTION
Put all version detection methods into a separate module. Detection from files can be generalized for any offset+length in a file plus any start and end byte pattern. Also added detection via game scan endpoint and via sophon download and patch information, where applicable. The network-accessing methods are lower in priority than purely local-file based ones.