### PR TITLE
Honkai sophon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ optional = true
 genshin = ["sophon"]
 star-rail = ["sophon"]
 zzz = []
-honkai = []
+honkai = ["sophon"]
 sophon = ["dep:sophon"]
 
 install = [

--- a/src/games/honkai/consts.rs
+++ b/src/games/honkai/consts.rs
@@ -117,3 +117,14 @@ impl GameEdition {
         }
     }
 }
+
+impl From<GameEdition> for sophon::GameEdition {
+    fn from(value: GameEdition) -> Self {
+        // Only as far as the API endpoint and launcher id is concerned. The game id is
+        // taken from non-sophon GameEdition
+        match value {
+            GameEdition::China => sophon::GameEdition::China,
+            _ => sophon::GameEdition::Global
+        }
+    }
+}

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -137,13 +137,27 @@ impl Game {
                         )
                         .inspect_err(|err| tracing::error!(?err, "getting download info error"))?;
 
-                        let download_info = game_downloads
+                        let game_download_info = game_downloads
                             .get_manifests_for("game")
                             .cloned()
                             .ok_or_else(|| anyhow::anyhow!("Failed to get game manifest"))?;
 
-                        let downloaded_size = download_info.stats.compressed_size.parse()?;
-                        let unpacked_size = download_info.stats.uncompressed_size.parse()?;
+                        let asb_download_info = game_downloads
+                            .get_manifests_for("asb")
+                            .cloned()
+                            .ok_or_else(|| anyhow::anyhow!("Failed to get asb manifest"))?;
+
+                        let game_downloaded_size: u64 =
+                            game_download_info.stats.compressed_size.parse()?;
+                        let game_unpacked_size: u64 =
+                            game_download_info.stats.uncompressed_size.parse()?;
+                        let asb_downloaded_size: u64 =
+                            asb_download_info.stats.compressed_size.parse()?;
+                        let asb_unpacked_size: u64 =
+                            asb_download_info.stats.uncompressed_size.parse()?;
+
+                        let downloaded_size = game_downloaded_size + asb_downloaded_size;
+                        let unpacked_size = game_unpacked_size + asb_unpacked_size;
 
                         return Ok(VersionDiff::NotInstalled {
                             latest: latest_version,
@@ -152,7 +166,8 @@ impl Game {
 
                             downloaded_size,
                             unpacked_size,
-                            download_info,
+                            game_download_info,
+                            asb_download_info,
 
                             installation_path: Some(self.path.clone()),
                             version_file_path: None,
@@ -184,29 +199,47 @@ impl Game {
                             &self.edition.into()
                         )?;
 
-                        let diff_info = diffs.get_manifests_for("game").unwrap().clone();
+                        let game_diff_info = diffs.get_manifests_for("game").unwrap().clone();
+                        let asb_diff_info = diffs.get_manifests_for("asb").unwrap().clone();
+
+                        let game_stats = game_diff_info
+                            .stats
+                            .get(&current.to_string())
+                            .map(|stats| {
+                                (
+                                    stats.compressed_size.parse::<u64>().unwrap(),
+                                    stats.uncompressed_size.parse::<u64>().unwrap()
+                                )
+                            })
+                            .unwrap_or((0, 0));
+
+                        let asb_stats = asb_diff_info
+                            .stats
+                            .get(&current.to_string())
+                            .map(|stats| {
+                                (
+                                    stats.compressed_size.parse::<u64>().unwrap(),
+                                    stats.uncompressed_size.parse::<u64>().unwrap()
+                                )
+                            })
+                            .unwrap_or((0, 0));
+
+                        let downloaded_size = game_stats.0 + asb_stats.0;
+                        let unpacked_size = game_stats.1 + asb_stats.1;
 
                         return Ok(VersionDiff::Predownload {
                             current,
                             latest: Version::from_str(&predownload_info.tag).unwrap(),
 
-                            downloaded_size: diff_info
-                                .stats
-                                .get(&current.to_string())
-                                .unwrap()
-                                .compressed_size
-                                .parse()
-                                .unwrap(),
+                            downloaded_size,
+                            unpacked_size,
 
-                            unpacked_size: diff_info
-                                .stats
-                                .get(&current.to_string())
-                                .unwrap()
-                                .uncompressed_size
-                                .parse()
-                                .unwrap(),
-
-                            download_info: sophon::api::schemas::DownloadOrDiff::Patch(diff_info),
+                            game_download_info: sophon::api::schemas::DownloadOrDiff::Patch(
+                                game_diff_info
+                            ),
+                            asb_download_info: sophon::api::schemas::DownloadOrDiff::Patch(
+                                asb_diff_info
+                            ),
                             edition: self.edition,
 
                             installation_path: Some(self.path.clone()),
@@ -242,31 +275,54 @@ impl Game {
                     .iter()
                     .any(|tag| *tag == current)
                 {
-                    for diff in &diffs.manifests {
-                        if diff.matching_field == "game" {
-                            if let Some((_, stats)) =
-                                diff.stats.iter().find(|(tag, _)| **tag == current)
-                            {
-                                let downloaded_size = stats.compressed_size.parse()?;
-                                let unpacked_size = stats.uncompressed_size.parse()?;
+                    let game_diff = diffs.get_manifests_for("game");
+                    let asb_diff = diffs.get_manifests_for("asb");
 
-                                return Ok(VersionDiff::Diff {
-                                    current,
-                                    latest: latest_version,
+                    let game_diff_stats = game_diff.and_then(|game_diff| {
+                        game_diff
+                            .stats
+                            .iter()
+                            .find(|(tag, _)| **tag == current)
+                            .map(|(_, stats)| stats)
+                    });
+                    let asb_diff_stats = asb_diff.and_then(|asb_diff| {
+                        asb_diff
+                            .stats
+                            .iter()
+                            .find(|(tag, _)| **tag == current)
+                            .map(|(_, stats)| stats)
+                    });
 
-                                    edition: self.edition,
+                    if game_diff_stats.is_some() || asb_diff_stats.is_some() {
+                        let downloaded_size = game_diff_stats
+                            .map(|stats| stats.compressed_size.parse::<u64>().unwrap())
+                            .unwrap_or(0)
+                            + asb_diff_stats
+                                .map(|stats| stats.compressed_size.parse::<u64>().unwrap())
+                                .unwrap_or(0);
+                        let unpacked_size = game_diff_stats
+                            .map(|stats| stats.uncompressed_size.parse::<u64>().unwrap())
+                            .unwrap_or(0)
+                            + asb_diff_stats
+                                .map(|stats| stats.uncompressed_size.parse::<u64>().unwrap())
+                                .unwrap_or(0);
 
-                                    downloaded_size,
-                                    unpacked_size,
+                        return Ok(VersionDiff::Diff {
+                            current,
+                            latest: latest_version,
 
-                                    diff: diff.clone(),
+                            edition: self.edition,
 
-                                    installation_path: Some(self.path.clone()),
-                                    version_file_path: None,
-                                    temp_folder: None
-                                });
-                            }
-                        }
+                            downloaded_size,
+                            unpacked_size,
+
+                            game_diff: game_diff.cloned(),
+                            asb_diff: asb_diff.cloned(),
+
+                            installation_path: Some(self.path.clone()),
+                            version_file_path: None,
+                            temp_folder: None
+                        });
                     }
                 }
 
@@ -290,13 +346,19 @@ impl Game {
             )
             .inspect_err(|err| tracing::error!(?err, "getting download info error"))?;
 
-            let download_info = game_downloads
+            let game_download_info = game_downloads
                 .get_manifests_for("game")
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("failed to get game manifest"))?;
+            let asb_download_info = game_downloads
+                .get_manifests_for("asb")
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("failed to get asb manifest"))?;
 
-            let downloaded_size = download_info.stats.compressed_size.parse()?;
-            let unpacked_size = download_info.stats.uncompressed_size.parse()?;
+            let downloaded_size = game_download_info.stats.compressed_size.parse::<u64>()?
+                + asb_download_info.stats.compressed_size.parse::<u64>()?;
+            let unpacked_size = game_download_info.stats.uncompressed_size.parse::<u64>()?
+                + asb_download_info.stats.uncompressed_size.parse::<u64>()?;
 
             Ok(VersionDiff::NotInstalled {
                 latest: latest_version,
@@ -304,7 +366,9 @@ impl Game {
 
                 downloaded_size,
                 unpacked_size,
-                download_info,
+
+                game_download_info,
+                asb_download_info,
 
                 installation_path: Some(self.path.clone()),
                 version_file_path: None,

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -1,6 +1,7 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use sophon::reqwest;
 
 use crate::version::Version;
 use crate::traits::game::GameExt;
@@ -105,76 +106,205 @@ impl Game {
     pub fn try_get_diff(&self) -> anyhow::Result<VersionDiff> {
         tracing::debug!("Trying to find version diff for the game");
 
-        let response = api::request(self.edition)?;
+        let client = reqwest::blocking::Client::new();
+
+        let game_branches = sophon::api::get_game_branches_info(&client, &self.edition.into())
+            .inspect_err(|err| tracing::error!(?err, "getting game branches error"))?;
+
+        let branch_info = game_branches
+            .get_game_branch_by_id_or_biz_latest(self.edition.api_game_id())
+            .ok_or_else(|| {
+                anyhow::anyhow!("failed to get the game version information")
+                    .context(format!("game id: {}", self.edition.api_game_id()))
+            })?;
+        let latest_version = branch_info
+            .version()
+            .expect("must be a valid version")
+            .into();
 
         if self.is_installed() {
-            let current = self.get_version()?;
+            let current = match self.get_version() {
+                Ok(version) => version,
+                Err(err) => {
+                    if self.path.exists() && self.path.metadata()?.len() == 0 {
+                        let game_downloads = sophon::api::get_game_download_sophon_info(
+                            &client,
+                            branch_info
+                                .main
+                                .as_ref()
+                                .expect("The `None` case would have been caught earlier"),
+                            &self.edition.into()
+                        )
+                        .inspect_err(|err| tracing::error!(?err, "getting download info error"))?;
 
-            if current >= response.main.major.version {
+                        let download_info = game_downloads
+                            .get_manifests_for("game")
+                            .cloned()
+                            .ok_or_else(|| anyhow::anyhow!("Failed to get game manifest"))?;
+
+                        let downloaded_size = download_info.stats.compressed_size.parse()?;
+                        let unpacked_size = download_info.stats.uncompressed_size.parse()?;
+
+                        return Ok(VersionDiff::NotInstalled {
+                            latest: latest_version,
+
+                            edition: self.edition,
+
+                            downloaded_size,
+                            unpacked_size,
+                            download_info,
+
+                            installation_path: Some(self.path.clone()),
+                            version_file_path: None,
+                            temp_folder: None
+                        });
+                    }
+
+                    return Err(err);
+                }
+            };
+
+            if current >= latest_version {
                 tracing::debug!("Game version is latest");
 
-                Ok(VersionDiff::Latest(current))
+                // If we're running latest game version the diff we need to download
+                // must always be `predownload.diffs[0]`, but just to be safe I made
+                // a loop through possible variants, and if none of them was correct
+                // (which is not possible in reality) we should just say that the game
+                // is latest
+                if let Some(predownload_info) = &branch_info.pre_download {
+                    if predownload_info
+                        .diff_tags
+                        .iter()
+                        .any(|pre_diff| *pre_diff == current)
+                    {
+                        let diffs = sophon::api::get_game_diffs_sophon_info(
+                            &client,
+                            predownload_info,
+                            &self.edition.into()
+                        )?;
+
+                        let diff_info = diffs.get_manifests_for("game").unwrap().clone();
+
+                        return Ok(VersionDiff::Predownload {
+                            current,
+                            latest: Version::from_str(&predownload_info.tag).unwrap(),
+
+                            downloaded_size: diff_info
+                                .stats
+                                .get(&current.to_string())
+                                .unwrap()
+                                .compressed_size
+                                .parse()
+                                .unwrap(),
+
+                            unpacked_size: diff_info
+                                .stats
+                                .get(&current.to_string())
+                                .unwrap()
+                                .uncompressed_size
+                                .parse()
+                                .unwrap(),
+
+                            download_info: sophon::api::schemas::DownloadOrDiff::Patch(diff_info),
+                            edition: self.edition,
+
+                            installation_path: Some(self.path.clone()),
+                            version_file_path: None,
+                            temp_folder: None
+                        });
+                    }
+                }
+
+                Ok(VersionDiff::Latest {
+                    version: current,
+                    edition: self.edition
+                })
             }
             else {
-                tracing::debug!(
-                    "Game is outdated: {} -> {}",
-                    current,
-                    response.main.major.version
-                );
+                tracing::debug!("Game is outdated: {} -> {}", current, latest_version);
 
-                Ok(VersionDiff::Diff {
-                    current,
-                    latest: Version::from_str(response.main.major.version).unwrap(),
-
-                    // TODO: can be a hard issue in future
-                    url: response.main.major.game_pkgs[0].url.clone(),
-
-                    downloaded_size: response
+                let diffs = sophon::api::get_game_diffs_sophon_info(
+                    &client,
+                    branch_info
                         .main
-                        .major
-                        .game_pkgs
-                        .iter()
-                        .flat_map(|pkg| pkg.size.parse::<u64>())
-                        .sum(),
+                        .as_ref()
+                        .expect("The `None` case would have been caught earlier"),
+                    &self.edition.into()
+                )
+                .context("Getting game diffs")?;
 
-                    unpacked_size: response
-                        .main
-                        .major
-                        .game_pkgs
-                        .iter()
-                        .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                        .sum(),
+                if branch_info
+                    .main
+                    .as_ref()
+                    .expect("The `None` case would have been caught earlier")
+                    .diff_tags
+                    .iter()
+                    .any(|tag| *tag == current)
+                {
+                    for diff in &diffs.manifests {
+                        if diff.matching_field == "game" {
+                            if let Some((_, stats)) =
+                                diff.stats.iter().find(|(tag, _)| **tag == current)
+                            {
+                                let downloaded_size = stats.compressed_size.parse()?;
+                                let unpacked_size = stats.uncompressed_size.parse()?;
 
-                    installation_path: Some(self.path.clone()),
-                    version_file_path: None,
-                    temp_folder: None
+                                return Ok(VersionDiff::Diff {
+                                    current,
+                                    latest: latest_version,
+
+                                    edition: self.edition,
+
+                                    downloaded_size,
+                                    unpacked_size,
+
+                                    diff: diff.clone(),
+
+                                    installation_path: Some(self.path.clone()),
+                                    version_file_path: None,
+                                    temp_folder: None
+                                });
+                            }
+                        }
+                    }
+                }
+
+                Ok(VersionDiff::Outdated {
+                    current,
+                    latest: latest_version,
+                    edition: self.edition
                 })
             }
         }
         else {
             tracing::debug!("Game is not installed");
 
+            let game_downloads = sophon::api::get_game_download_sophon_info(
+                &client,
+                branch_info
+                    .main
+                    .as_ref()
+                    .expect("The `None` case would have been caught earlier"),
+                &self.edition.into()
+            )
+            .inspect_err(|err| tracing::error!(?err, "getting download info error"))?;
+
+            let download_info = game_downloads
+                .get_manifests_for("game")
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("failed to get game manifest"))?;
+
+            let downloaded_size = download_info.stats.compressed_size.parse()?;
+            let unpacked_size = download_info.stats.uncompressed_size.parse()?;
+
             Ok(VersionDiff::NotInstalled {
-                latest: Version::from_str(&response.main.major.version).unwrap(),
+                latest: latest_version,
+                edition: self.edition,
 
-                // TODO: can be a hard issue in future
-                url: response.main.major.game_pkgs[0].url.clone(),
-
-                downloaded_size: response
-                    .main
-                    .major
-                    .game_pkgs
-                    .iter()
-                    .flat_map(|pkg| pkg.size.parse::<u64>())
-                    .sum(),
-
-                unpacked_size: response
-                    .main
-                    .major
-                    .game_pkgs
-                    .iter()
-                    .flat_map(|pkg| pkg.decompressed_size.parse::<u64>())
-                    .sum(),
+                downloaded_size,
+                unpacked_size,
+                download_info,
 
                 installation_path: Some(self.path.clone()),
                 version_file_path: None,

--- a/src/games/honkai/repairer.rs
+++ b/src/games/honkai/repairer.rs
@@ -1,48 +1,91 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use cached::proc_macro::cached;
 
-use super::api;
-use super::consts::GameEdition;
-
 use crate::repairer::IntegrityFile;
+use crate::sophon;
+use crate::sophon::reqwest;
+use super::consts::GameEdition;
+use super::voice_data::locale::VoiceLocale;
 
-fn try_get_some_integrity_files<T: AsRef<str>>(game_edition: GameEdition, file_name: T, timeout: Option<u64>) -> anyhow::Result<Vec<IntegrityFile>> {
-    let decompressed_path = api::request(game_edition)?.main.major.res_list_url;
+// TODO: utilize the `timeout` variable!
 
-    let pkg_version = minreq::get(format!("{decompressed_path}/{}", file_name.as_ref()))
-        .with_timeout(timeout.unwrap_or(*crate::REQUESTS_TIMEOUT))
-        .send()?;
+fn try_get_some_integrity_files(
+    game_edition: GameEdition,
+    matching_field: &str,
+    _timeout: Option<u64>
+) -> anyhow::Result<Vec<IntegrityFile>> {
+    let client = reqwest::blocking::Client::new();
 
-    let mut files = Vec::new();
+    let game_branches = sophon::api::get_game_branches_info(&client, &game_edition.into())?;
 
-    for line in String::from_utf8_lossy(pkg_version.as_bytes()).lines() {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(line) {
-            files.push(IntegrityFile {
-                path: PathBuf::from(value["remoteName"].as_str().unwrap()),
-                md5: value["md5"].as_str().unwrap().to_string(),
-                size: value["fileSize"].as_u64().unwrap(),
-                base_url: decompressed_path.clone()
-            });
-        }
-    }
+    let game_branch_info = game_branches
+        .get_game_branch_by_id_or_biz_latest(game_edition.api_game_id())
+        .ok_or_else(|| {
+            anyhow::anyhow!("failed to get the game version information")
+                .context(format!("game id: {}", game_edition.api_game_id()))
+        })?;
+
+    let downloads = sophon::api::get_game_download_sophon_info(
+        &client,
+        game_branch_info
+            .main
+            .as_ref()
+            .expect("The `None` case would have been caught earlier"),
+        &game_edition.into()
+    )?;
+
+    let download_info = downloads
+        .manifests
+        .iter()
+        .find(|download_info| download_info.matching_field == matching_field)
+        .ok_or_else(|| {
+            anyhow::anyhow!("failed to find game download info")
+                .context(format!("matching field: {matching_field}"))
+        })?;
+
+    let download_manifest = sophon::api::get_download_manifest(&client, download_info)?;
+
+    let files = download_manifest
+        .assets
+        .iter()
+        .map(IntegrityFile::from)
+        .collect::<Vec<_>>();
 
     Ok(files)
 }
 
-/// Try to list latest game files
+/// Try to list latest game files.
 #[cached(result)]
-pub fn try_get_integrity_files(game_edition: GameEdition, timeout: Option<u64>) -> anyhow::Result<Vec<IntegrityFile>> {
-    try_get_some_integrity_files(game_edition, "pkg_version", timeout)
+pub fn try_get_integrity_files(
+    game_edition: GameEdition,
+    timeout: Option<u64>
+) -> anyhow::Result<Vec<IntegrityFile>> {
+    try_get_some_integrity_files(game_edition, "game", timeout)
 }
 
-/// Try to get specific integrity file
-/// 
-/// `relative_path` must be relative to the game's root folder, so
-/// if your file is e.g. `/path/to/[AnimeGame]/[AnimeGame_Data]/level0`, then root folder is `/path/to/[AnimeGame]`,
-/// and `relative_path` must be `[AnimeGame_Data]/level0`
-pub fn try_get_integrity_file<T: Into<PathBuf>>(game_edition: GameEdition, relative_path: T, timeout: Option<u64>) -> anyhow::Result<Option<IntegrityFile>> {
-    let relative_path = relative_path.into();
+/// Try to list latest voice package files.
+#[cached(result)]
+pub fn try_get_voice_integrity_files(
+    game_edition: GameEdition,
+    locale: VoiceLocale,
+    timeout: Option<u64>
+) -> anyhow::Result<Vec<IntegrityFile>> {
+    try_get_some_integrity_files(game_edition, locale.to_code(), timeout)
+}
+
+/// Try to get specific integrity file.
+///
+/// `relative_path` must be relative to the game's root folder, so if your file
+/// is e.g. `/path/to/[AnimeGame]/[AnimeGame_Data]/level0`, then root folder is
+/// `/path/to/[AnimeGame]`, and `relative_path` must be
+/// `[AnimeGame_Data]/level0`.
+pub fn try_get_integrity_file(
+    game_edition: GameEdition,
+    relative_path: impl AsRef<Path>,
+    timeout: Option<u64>
+) -> anyhow::Result<Option<IntegrityFile>> {
+    let relative_path = relative_path.as_ref();
 
     if let Ok(files) = try_get_integrity_files(game_edition, timeout) {
         for file in files {
@@ -52,15 +95,31 @@ pub fn try_get_integrity_file<T: Into<PathBuf>>(game_edition: GameEdition, relat
         }
     }
 
+    for lang in VoiceLocale::list() {
+        if let Ok(files) = try_get_voice_integrity_files(game_edition, *lang, timeout) {
+            for file in files {
+                if file.path == relative_path {
+                    return Ok(Some(file));
+                }
+            }
+        }
+    }
+
     Ok(None)
 }
 
-/// Try to get list of files that are not more used by the game and can be deleted
-/// 
-/// ⚠️ Be aware that the game can create its own files after downloading, so "unused files" may not be really unused.
-/// It's strongly recommended to use this function only with manual control from user's side, in example to show him
-/// paths to these files and let him choose what to do with them
-pub fn try_get_unused_files<T: Into<PathBuf>>(game_edition: GameEdition, game_dir: T, timeout: Option<u64>) -> anyhow::Result<Vec<PathBuf>> {
+/// Try to get list of files that are not more used by the game and can be
+/// deleted.
+///
+/// ⚠️ Be aware that the game can create its own files after downloading, so
+/// "unused files" may not be really unused. It's strongly recommended to use
+/// this function only with manual control from user's side, in example to show
+/// him paths to these files and let him choose what to do with them.
+pub fn try_get_unused_files(
+    game_edition: GameEdition,
+    game_dir: impl Into<PathBuf>,
+    timeout: Option<u64>
+) -> anyhow::Result<Vec<PathBuf>> {
     let used_files = try_get_integrity_files(game_edition, timeout)?
         .into_iter()
         .map(|file| file.path)
@@ -69,8 +128,30 @@ pub fn try_get_unused_files<T: Into<PathBuf>>(game_edition: GameEdition, game_di
     let skip_names = [
         String::from("webCaches"),
         String::from("SDKCaches"),
-        String::from("ScreenShot"),
+        String::from("GeneratedSoundBanks"),
+        String::from("ScreenShot")
     ];
 
     crate::repairer::try_get_unused_files(game_dir, used_files, skip_names)
+}
+
+/// Try to get list of files that are not more used by the game and can be
+/// deleted.
+///
+/// ⚠️ Be aware that the game can create its own files after downloading, so
+/// "unused files" may not be really unused. It's strongly recommended to use
+/// this function only with manual control from user's side, in example to show
+/// him paths to these files and let him choose what to do with them.
+pub fn try_get_unused_voice_files(
+    game_edition: GameEdition,
+    game_dir: impl Into<PathBuf>,
+    locale: VoiceLocale,
+    timeout: Option<u64>
+) -> anyhow::Result<Vec<PathBuf>> {
+    let used_files = try_get_voice_integrity_files(game_edition, locale, timeout)?
+        .into_iter()
+        .map(|file| file.path)
+        .collect::<Vec<PathBuf>>();
+
+    crate::repairer::try_get_unused_files(game_dir, used_files, [])
 }

--- a/src/games/honkai/repairer.rs
+++ b/src/games/honkai/repairer.rs
@@ -6,7 +6,6 @@ use crate::repairer::IntegrityFile;
 use crate::sophon;
 use crate::sophon::reqwest;
 use super::consts::GameEdition;
-use super::voice_data::locale::VoiceLocale;
 
 // TODO: utilize the `timeout` variable!
 
@@ -64,16 +63,6 @@ pub fn try_get_integrity_files(
     try_get_some_integrity_files(game_edition, "game", timeout)
 }
 
-/// Try to list latest voice package files.
-#[cached(result)]
-pub fn try_get_voice_integrity_files(
-    game_edition: GameEdition,
-    locale: VoiceLocale,
-    timeout: Option<u64>
-) -> anyhow::Result<Vec<IntegrityFile>> {
-    try_get_some_integrity_files(game_edition, locale.to_code(), timeout)
-}
-
 /// Try to get specific integrity file.
 ///
 /// `relative_path` must be relative to the game's root folder, so if your file
@@ -91,16 +80,6 @@ pub fn try_get_integrity_file(
         for file in files {
             if file.path == relative_path {
                 return Ok(Some(file));
-            }
-        }
-    }
-
-    for lang in VoiceLocale::list() {
-        if let Ok(files) = try_get_voice_integrity_files(game_edition, *lang, timeout) {
-            for file in files {
-                if file.path == relative_path {
-                    return Ok(Some(file));
-                }
             }
         }
     }
@@ -133,25 +112,4 @@ pub fn try_get_unused_files(
     ];
 
     crate::repairer::try_get_unused_files(game_dir, used_files, skip_names)
-}
-
-/// Try to get list of files that are not more used by the game and can be
-/// deleted.
-///
-/// ⚠️ Be aware that the game can create its own files after downloading, so
-/// "unused files" may not be really unused. It's strongly recommended to use
-/// this function only with manual control from user's side, in example to show
-/// him paths to these files and let him choose what to do with them.
-pub fn try_get_unused_voice_files(
-    game_edition: GameEdition,
-    game_dir: impl Into<PathBuf>,
-    locale: VoiceLocale,
-    timeout: Option<u64>
-) -> anyhow::Result<Vec<PathBuf>> {
-    let used_files = try_get_voice_integrity_files(game_edition, locale, timeout)?
-        .into_iter()
-        .map(|file| file.path)
-        .collect::<Vec<PathBuf>>();
-
-    crate::repairer::try_get_unused_files(game_dir, used_files, [])
 }

--- a/src/games/honkai/version_diff.rs
+++ b/src/games/honkai/version_diff.rs
@@ -280,9 +280,13 @@ impl VersionDiff {
             installer.inplace = true;
 
             let updater_clone = updater.clone();
-            installer.install(path.as_ref(), thread_count, move |msg| {
-                (updater_clone)(msg.into());
-            })?;
+            installer.install(
+                path.as_ref(),
+                thread_count,
+                Box::new(move |msg| {
+                    (updater_clone)(msg.into());
+                })
+            )?;
 
             tracing::debug!(
                 temp = ?installer.downloading_temp(),
@@ -300,9 +304,13 @@ impl VersionDiff {
             installer.chunks_queue_data_limit = Some(2048 * 1024 * 1024); // 2GiB
             installer.inplace = true;
 
-            installer.install(path.as_ref(), thread_count, move |msg| {
-                (updater)(msg.into());
-            })?;
+            installer.install(
+                path.as_ref(),
+                thread_count,
+                Box::new(move |msg| {
+                    (updater)(msg.into());
+                })
+            )?;
 
             tracing::debug!(
                 temp = ?installer.downloading_temp(),
@@ -352,9 +360,14 @@ impl VersionDiff {
                     SophonPatcher::new(client.clone(), asb_diff, self.temp_folder(), None)?;
 
                 let updater_clone = updater.clone();
-                patcher.update(&path, from.into(), thread_count, move |msg| {
-                    (updater_clone)(msg.into());
-                })?;
+                patcher.update(
+                    &path,
+                    from.into(),
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater_clone)(msg.into());
+                    })
+                )?;
 
                 tracing::debug!(
                     temp = ?patcher.files_temp(),
@@ -370,9 +383,14 @@ impl VersionDiff {
             tracing::info_span!("Updating `game`").in_scope(|| {
                 let patcher = SophonPatcher::new(client, game_diff, self.temp_folder(), None)?;
 
-                patcher.update(&path, from.into(), thread_count, move |msg| {
-                    (updater)(msg.into());
-                })?;
+                patcher.update(
+                    &path,
+                    from.into(),
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater)(msg.into());
+                    })
+                )?;
 
                 // Create `.version` file here even if hdiff patching is failed because
                 // it's easier to explain user why he should run files repairer than
@@ -421,18 +439,25 @@ impl VersionDiff {
                 let installer =
                     SophonInstaller::new(client.clone(), download_info, self.temp_folder())?;
 
-                installer.pre_download(thread_count, move |msg| {
-                    (updater_clone)(msg.into());
-                })?;
+                installer.pre_download(
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater_clone)(msg.into());
+                    })
+                )?;
             }
 
             DownloadOrDiff::Patch(diff_info) => {
                 let patcher =
                     SophonPatcher::new(client.clone(), diff_info, self.temp_folder(), None)?;
 
-                patcher.pre_download(from.into(), thread_count, move |msg| {
-                    (updater_clone)(msg.into());
-                })?;
+                patcher.pre_download(
+                    from.into(),
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater_clone)(msg.into());
+                    })
+                )?;
             }
         }
 
@@ -440,21 +465,57 @@ impl VersionDiff {
             DownloadOrDiff::Download(download_info) => {
                 let installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
 
-                installer.pre_download(thread_count, move |msg| {
-                    (updater)(msg.into());
-                })?;
+                installer.pre_download(
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater)(msg.into());
+                    })
+                )?;
             }
 
             DownloadOrDiff::Patch(diff_info) => {
                 let patcher = SophonPatcher::new(client, diff_info, self.temp_folder(), None)?;
 
-                patcher.pre_download(from.into(), thread_count, move |msg| {
-                    (updater)(msg.into());
-                })?;
+                patcher.pre_download(
+                    from.into(),
+                    thread_count,
+                    Box::new(move |msg| {
+                        (updater)(msg.into());
+                    })
+                )?;
             }
         }
 
         Ok(())
+    }
+
+    /// Get the matching field value for this diff. Returns none in case of
+    /// [`VersionDiff::Latest`] or [`VersionDiff::Outdated`]
+    pub fn matching_field(&self) -> Option<&str> {
+        match self {
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
+            Self::Predownload {
+                game_download_info, ..
+            } => match download_info {
+                DownloadOrDiff::Patch(SophonDiff {
+                    matching_field, ..
+                })
+                | DownloadOrDiff::Download(SophonDownloadInfo {
+                    matching_field, ..
+                }) => Some(matching_field)
+            },
+            Self::Diff {
+                diff, ..
+            } => Some(&diff.matching_field),
+            Self::NotInstalled {
+                download_info, ..
+            } => Some(&download_info.matching_field)
+        }
     }
 }
 

--- a/src/games/honkai/version_diff.rs
+++ b/src/games/honkai/version_diff.rs
@@ -1,22 +1,52 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sophon::{SophonError, reqwest};
+use sophon::updater::SophonPatcher;
+use sophon::api::schemas::sophon_diff::SophonDiff;
+use sophon::api::schemas::DownloadOrDiff;
+use sophon::api::schemas::sophon_manifests::SophonDownloadInfo;
+use sophon::installer::SophonInstaller;
 use thiserror::Error;
 
+use crate::honkai::consts::GameEdition;
 use crate::version::Version;
 use crate::traits::version_diff::VersionDiffExt;
 #[cfg(feature = "install")]
-use crate::installer::{
-    downloader::{Downloader, DownloadingError},
-    free_space,
-    installer::{Installer, Update as InstallerUpdate}
-};
+use crate::installer::downloader::DownloadingError;
 
-#[derive(Error, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug)]
+pub enum DiffUpdate {
+    Installer(sophon::installer::Update),
+    Patcher(sophon::updater::Update)
+}
+
+impl From<sophon::updater::Update> for DiffUpdate {
+    fn from(v: sophon::updater::Update) -> Self {
+        Self::Patcher(v)
+    }
+}
+
+impl From<sophon::installer::Update> for DiffUpdate {
+    fn from(v: sophon::installer::Update) -> Self {
+        Self::Installer(v)
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum DiffDownloadingError {
     /// Your installation is already up to date and not needed to be updated
     #[error("Component version is already latest")]
     AlreadyLatest,
+
+    /// Current version is too outdated and can't be updated.
+    /// It means that you have to download everything from zero
+    #[error("Components version is too outdated and can't be updated")]
+    Outdated,
+
+    /// When there's multiple urls and you can't save them as a single file
+    #[error("Component has multiple downloading urls and can't be saved as a single file")]
+    MultipleSegments,
 
     /// Failed to fetch remove data. Redirected from `Downloader`
     #[error("{0}")]
@@ -28,7 +58,11 @@ pub enum DiffDownloadingError {
     /// your game installation path and thus indicates that it doesn't know
     /// where this package needs to be installed
     #[error("Path to the component's downloading folder is not specified")]
-    PathNotSpecified
+    PathNotSpecified,
+
+    /// Sophon download/patch error
+    #[error("{0}")]
+    SophonError(#[from] SophonError)
 }
 
 impl From<minreq::Error> for DiffDownloadingError {
@@ -40,13 +74,18 @@ impl From<minreq::Error> for DiffDownloadingError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VersionDiff {
     /// Latest version
-    Latest(Version),
+    Latest {
+        version: Version,
+        edition: GameEdition
+    },
 
-    /// Component should be updated before using it
-    Diff {
+    /// Component's update can be predownloaded, but you still can use it
+    Predownload {
         current: Version,
         latest: Version,
-        url: String,
+
+        download_info: DownloadOrDiff,
+        edition: GameEdition,
 
         downloaded_size: u64,
         unpacked_size: u64,
@@ -65,10 +104,43 @@ pub enum VersionDiff {
         temp_folder: Option<PathBuf>
     },
 
+    /// Component should be updated before using it
+    Diff {
+        current: Version,
+        latest: Version,
+
+        diff: SophonDiff,
+        edition: GameEdition,
+
+        downloaded_size: u64,
+        unpacked_size: u64,
+
+        /// Path to the folder this difference should be installed by the
+        /// `install` method
+        ///
+        /// This value can be `None`, so `install` will return
+        /// `Err(DiffDownloadError::PathNotSpecified)`
+        installation_path: Option<PathBuf>,
+
+        /// Optional path to the `.version` file
+        version_file_path: Option<PathBuf>,
+
+        /// Temp folder path
+        temp_folder: Option<PathBuf>
+    },
+
+    /// Difference can't be calculated because installed version is too old
+    Outdated {
+        current: Version,
+        latest: Version,
+        edition: GameEdition
+    },
+
     /// Component is not yet installed
     NotInstalled {
         latest: Version,
-        url: String,
+        download_info: SophonDownloadInfo,
+        edition: GameEdition,
 
         downloaded_size: u64,
         unpacked_size: u64,
@@ -93,13 +165,21 @@ impl VersionDiff {
     pub fn version_file_path(&self) -> Option<PathBuf> {
         match self {
             // Can't be installed
-            Self::Latest(_) => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
             Self::Diff {
                 version_file_path, ..
             }
             | Self::NotInstalled {
+                version_file_path, ..
+            }
+            | Self::Predownload {
                 version_file_path, ..
             } => version_file_path.to_owned()
         }
@@ -111,7 +191,12 @@ impl VersionDiff {
     pub fn temp_folder(&self) -> PathBuf {
         match self {
             // Can't be installed
-            Self::Latest(_) => std::env::temp_dir(),
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => std::env::temp_dir(),
 
             // Can be installed
             Self::Diff {
@@ -119,19 +204,35 @@ impl VersionDiff {
             }
             | Self::NotInstalled {
                 temp_folder, ..
-            } => match temp_folder {
-                Some(path) => path.to_owned(),
-                None => std::env::temp_dir()
             }
+            | Self::Predownload {
+                temp_folder, ..
+            } => temp_folder
+                .as_ref()
+                .map(PathBuf::to_owned)
+                .unwrap_or_else(std::env::temp_dir)
         }
     }
 
     pub fn with_temp_folder(mut self, temp: PathBuf) -> Self {
         match &mut self {
             // Can't be installed
-            Self::Latest(_) => self,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => self,
 
             // Can be installed
+            Self::Predownload {
+                temp_folder, ..
+            } => {
+                *temp_folder = Some(temp);
+
+                self
+            }
+
             Self::Diff {
                 temp_folder, ..
             } => {
@@ -149,22 +250,202 @@ impl VersionDiff {
             }
         }
     }
+
+    fn download_game(
+        &self,
+        download_info: &SophonDownloadInfo,
+        thread_count: usize,
+        path: impl AsRef<Path>,
+        updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
+    ) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::debug!(
+            path = ?path.as_ref(),
+            info = ?download_info,
+            "Downloading game"
+        );
+
+        let client = reqwest::blocking::Client::new();
+
+        let mut installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
+        installer.chunks_in_mem = true;
+        installer.chunks_queue_data_limit = Some(2048 * 1024 * 1024); // 2GiB
+        installer.inplace = true;
+
+        installer.install(path.as_ref(), thread_count, move |msg| {
+            (updater)(msg.into());
+        })?;
+
+        // Create `.version` file here even if hdiff patching is failed because
+        // it's easier to explain user why he should run files repairer than
+        // why he should re-download entire game update because something is failed
+        #[allow(unused_must_use)]
+        {
+            let version_path = self
+                .version_file_path()
+                .unwrap_or(path.as_ref().join(".version"));
+
+            std::fs::write(version_path, self.latest().to_string());
+        }
+
+        tracing::debug!(
+            temp = ?installer.downloading_temp(),
+            "Removing game downloading cache"
+        );
+
+        let _ = std::fs::remove_dir_all(installer.downloading_temp());
+
+        Ok(())
+    }
+
+    fn patch_game(
+        &self,
+        from: Version,
+        thread_count: usize,
+        diff: &SophonDiff,
+        path: impl AsRef<Path>,
+        updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
+    ) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::debug!(
+            path = ?path.as_ref(),
+            from_version = from.to_string(),
+            ?diff,
+            "Patching game files"
+        );
+
+        let client = reqwest::blocking::Client::new();
+
+        let patcher = SophonPatcher::new(client, diff, self.temp_folder(), None)?;
+
+        patcher.update(&path, from.into(), thread_count, move |msg| {
+            (updater)(msg.into());
+        })?;
+
+        // Create `.version` file here even if hdiff patching is failed because
+        // it's easier to explain user why he should run files repairer than
+        // why he should re-download entire game update because something is failed
+        #[allow(unused_must_use)]
+        {
+            let version_path = self
+                .version_file_path()
+                .unwrap_or(path.as_ref().join(".version"));
+
+            std::fs::write(version_path, self.latest().to_string());
+        }
+
+        tracing::debug!(
+            temp = ?patcher.files_temp(),
+            "Removing patching cache"
+        );
+
+        let _ = std::fs::remove_dir_all(patcher.files_temp());
+
+        Ok(())
+    }
+
+    fn pre_download(
+        &self,
+        download_or_patch_info: &DownloadOrDiff,
+        from: Version,
+        thread_count: usize,
+        updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
+    ) -> Result<(), <Self as VersionDiffExt>::Error> {
+        tracing::debug!(
+            from_version = from.to_string(),
+            diff = ?download_or_patch_info,
+            "Predownloading game update"
+        );
+
+        let client = reqwest::blocking::Client::new();
+
+        match download_or_patch_info {
+            DownloadOrDiff::Download(download_info) => {
+                let installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
+
+                installer.pre_download(thread_count, move |msg| {
+                    (updater)(msg.into());
+                })?;
+            }
+
+            DownloadOrDiff::Patch(diff_info) => {
+                let patcher = SophonPatcher::new(client, diff_info, self.temp_folder(), None)?;
+
+                patcher.pre_download(from.into(), thread_count, move |msg| {
+                    (updater)(msg.into());
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the matching field value for this diff. Returns none in case of
+    /// [`VersionDiff::Latest`] or [`VersionDiff::Outdated`]
+    pub fn matching_field(&self) -> Option<&str> {
+        match self {
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
+            Self::Predownload {
+                download_info, ..
+            } => match download_info {
+                DownloadOrDiff::Patch(SophonDiff {
+                    matching_field, ..
+                })
+                | DownloadOrDiff::Download(SophonDownloadInfo {
+                    matching_field, ..
+                }) => Some(matching_field)
+            },
+            Self::Diff {
+                diff, ..
+            } => Some(&diff.matching_field),
+            Self::NotInstalled {
+                download_info, ..
+            } => Some(&download_info.matching_field)
+        }
+    }
 }
 
 impl VersionDiffExt for VersionDiff {
-    type Edition = ();
+    type Edition = GameEdition;
     type Error = DiffDownloadingError;
-    type Update = InstallerUpdate;
+    type Update = DiffUpdate;
 
     #[inline]
     fn edition(&self) -> Self::Edition {
-        ()
+        match self {
+            Self::Latest {
+                edition, ..
+            }
+            | Self::Predownload {
+                edition, ..
+            }
+            | Self::Diff {
+                edition, ..
+            }
+            | Self::Outdated {
+                edition, ..
+            }
+            | Self::NotInstalled {
+                edition, ..
+            } => *edition
+        }
     }
 
     fn current(&self) -> Option<Version> {
         match self {
-            Self::Latest(current)
+            Self::Latest {
+                version: current, ..
+            }
+            | Self::Predownload {
+                current, ..
+            }
             | Self::Diff {
+                current, ..
+            }
+            | Self::Outdated {
                 current, ..
             } => Some(*current),
 
@@ -176,8 +457,16 @@ impl VersionDiffExt for VersionDiff {
 
     fn latest(&self) -> Version {
         match self {
-            Self::Latest(latest)
+            Self::Latest {
+                version: latest, ..
+            }
+            | Self::Predownload {
+                latest, ..
+            }
             | Self::Diff {
+                latest, ..
+            }
+            | Self::Outdated {
                 latest, ..
             }
             | Self::NotInstalled {
@@ -189,10 +478,18 @@ impl VersionDiffExt for VersionDiff {
     fn downloaded_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest(_) => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
             Self::Diff {
+                downloaded_size, ..
+            }
+            | Self::Predownload {
                 downloaded_size, ..
             }
             | Self::NotInstalled {
@@ -204,10 +501,18 @@ impl VersionDiffExt for VersionDiff {
     fn unpacked_size(&self) -> Option<u64> {
         match self {
             // Can't be installed
-            Self::Latest(_) => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
             Self::Diff {
+                unpacked_size, ..
+            }
+            | Self::Predownload {
                 unpacked_size, ..
             }
             | Self::NotInstalled {
@@ -219,10 +524,18 @@ impl VersionDiffExt for VersionDiff {
     fn installation_path(&self) -> Option<&Path> {
         match self {
             // Can't be installed
-            Self::Latest(_) => None,
+            Self::Latest {
+                ..
+            }
+            | Self::Outdated {
+                ..
+            } => None,
 
             // Can be installed
             Self::Diff {
+                installation_path, ..
+            }
+            | Self::Predownload {
                 installation_path, ..
             }
             | Self::NotInstalled {
@@ -235,44 +548,67 @@ impl VersionDiffExt for VersionDiff {
     }
 
     fn downloading_uri(&self) -> Option<String> {
-        match self {
-            // Can't be installed
-            Self::Latest(_) => None,
-
-            // Can be installed
-            Self::Diff {
-                url, ..
-            }
-            | Self::NotInstalled {
-                url, ..
-            } => Some(url.to_owned())
-        }
+        // because sophon
+        None
     }
 
     fn download_as(
         &mut self,
-        path: impl AsRef<Path>,
-        progress: impl Fn(u64, u64) + Send + 'static
+        _path: impl AsRef<Path>,
+        _progress: impl Fn(u64, u64) + Send + 'static
     ) -> Result<(), Self::Error> {
         tracing::debug!("Downloading version difference");
 
-        let mut downloader = Downloader::new(match self {
-            // Can't be downloaded
-            Self::Latest(_) => return Err(Self::Error::AlreadyLatest),
+        match self {
+            Self::Latest {
+                ..
+            } => Err(Self::Error::AlreadyLatest),
+            _ => Err(Self::Error::MultipleSegments)
+        }
+    }
 
-            // Can be downloaded
-            Self::Diff {
-                url, ..
-            }
-            | Self::NotInstalled {
-                url, ..
-            } => url
-        })?;
+    // Reimplemented for predownloading. Since self.file_name() returns None, the
+    // implementation provided in trait definition won't work.
+    //
+    // Implemented based on observation that the method is only called for
+    // predownloads in the launcher itself.
+    fn download_to(
+        &mut self,
+        folder: impl AsRef<Path>,
+        progress: impl Fn(u64, u64) + Send + 'static
+    ) -> Result<(), Self::Error> {
+        if matches!(self, Self::Predownload { .. }) {
+            // non-sync and non-clone progress callback was provided, so have
+            // to do stuff like this
+            let (sender, recver) = std::sync::mpsc::channel();
 
-        if let Err(err) = downloader.download(path.as_ref(), progress) {
-            tracing::error!("Failed to download version difference: {err}");
+            let proxy_thread_handle = std::thread::spawn(move || {
+                while let Ok((downloaded, total)) = recver.recv() {
+                    (progress)(downloaded, total);
+                }
+            });
 
-            return Err(err.into());
+            self.install_to(folder, 1, move |msg| match msg {
+                DiffUpdate::Patcher(sophon::updater::Update::DownloadingProgressBytes {
+                    downloaded_bytes,
+                    total_bytes
+                }) => {
+                    let _ = sender.send((downloaded_bytes, total_bytes));
+                }
+
+                DiffUpdate::Installer(sophon::installer::Update::DownloadingProgressBytes {
+                    downloaded_bytes,
+                    total_bytes
+                }) => {
+                    let _ = sender.send((downloaded_bytes, total_bytes));
+                }
+
+                _ => ()
+            })?;
+
+            proxy_thread_handle
+                .join()
+                .expect("failed to join game downloader thread");
         }
 
         Ok(())
@@ -281,104 +617,33 @@ impl VersionDiffExt for VersionDiff {
     fn install_to(
         &self,
         path: impl AsRef<Path>,
-        _thread_count: usize,
+        thread_count: usize,
         updater: impl Fn(Self::Update) + Clone + Send + 'static
     ) -> Result<(), Self::Error> {
         tracing::debug!("Installing version difference");
 
-        let path = path.as_ref();
+        match self {
+            Self::Latest {
+                ..
+            } => Err(Self::Error::AlreadyLatest),
+            Self::Outdated {
+                ..
+            } => Err(Self::Error::Outdated),
 
-        let url = self
-            .downloading_uri()
-            .expect("Failed to retreive downloading url");
-        let downloaded_size = self
-            .downloaded_size()
-            .expect("Failed to retreive downloaded size");
-        let unpacked_size = self
-            .unpacked_size()
-            .expect("Failed to retreive unpacked size");
+            Self::Diff {
+                diff,
+                current,
+                ..
+            } => self.patch_game(*current, thread_count, diff, path, updater),
+            Self::NotInstalled {
+                download_info, ..
+            } => self.download_game(download_info, thread_count, path, updater),
 
-        let mut installer = Installer::new(url)?
-            // Set custom temp folder location
-            .with_temp_folder(self.temp_folder())
-            // Don't perform space checks in the Installer because we're doing it here
-            .with_free_space_check(false);
-
-        (updater)(InstallerUpdate::CheckingFreeSpace(
-            installer.temp_folder.to_path_buf()
-        ));
-
-        // Check available free space for archive itself
-        let Some(space) = free_space::available(&installer.temp_folder)
-        else {
-            tracing::error!("Path is not mounted: {:?}", installer.temp_folder);
-
-            return Err(DownloadingError::PathNotMounted(installer.temp_folder).into());
-        };
-
-        // We can possibly store downloaded archive + unpacked data on the same disk
-        let required = if free_space::is_same_disk(&installer.temp_folder, path) {
-            downloaded_size + unpacked_size
+            Self::Predownload {
+                download_info,
+                current,
+                ..
+            } => self.pre_download(download_info, *current, thread_count, updater)
         }
-        else {
-            downloaded_size
-        };
-
-        if space < required {
-            tracing::error!(
-                "No free space available in the temp folder. Required: {required}. Available: {space}"
-            );
-
-            return Err(
-                DownloadingError::NoSpaceAvailable(installer.temp_folder, required, space).into()
-            );
-        }
-
-        (updater)(InstallerUpdate::CheckingFreeSpace(path.to_path_buf()));
-
-        // Check available free space for unpacked archvie data
-        let Some(space) = free_space::available(&path)
-        else {
-            tracing::error!("Path is not mounted: {:?}", &path);
-
-            return Err(DownloadingError::PathNotMounted(path.to_path_buf()).into());
-        };
-
-        // We can possibly store downloaded archive + unpacked data on the same disk
-        let required = if free_space::is_same_disk(&path, &installer.temp_folder) {
-            unpacked_size + downloaded_size
-        }
-        else {
-            unpacked_size
-        };
-
-        if space < required {
-            tracing::error!(
-                "No free space available in the installation folder. Required: {required}. Available: {space}"
-            );
-
-            return Err(
-                DownloadingError::NoSpaceAvailable(path.to_path_buf(), required, space).into()
-            );
-        }
-
-        // Install data
-        let installer_updater = updater.clone();
-
-        installer.install(path, move |update| (installer_updater)(update));
-
-        // Create `.version` file here even if hdiff patching is failed because
-        // it's easier to explain user why he should run files repairer than
-        // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)]
-        {
-            let version_path = self
-                .version_file_path()
-                .unwrap_or_else(|| path.join(".version"));
-
-            std::fs::write(version_path, self.latest().to_string());
-        }
-
-        Ok(())
     }
 }

--- a/src/games/honkai/version_diff.rs
+++ b/src/games/honkai/version_diff.rs
@@ -84,7 +84,8 @@ pub enum VersionDiff {
         current: Version,
         latest: Version,
 
-        download_info: DownloadOrDiff,
+        game_download_info: DownloadOrDiff,
+        asb_download_info: DownloadOrDiff,
         edition: GameEdition,
 
         downloaded_size: u64,
@@ -109,7 +110,10 @@ pub enum VersionDiff {
         current: Version,
         latest: Version,
 
-        diff: SophonDiff,
+        // `game` might not ever have an update
+        game_diff: Option<SophonDiff>,
+        asb_diff: Option<SophonDiff>,
+
         edition: GameEdition,
 
         downloaded_size: u64,
@@ -139,7 +143,8 @@ pub enum VersionDiff {
     /// Component is not yet installed
     NotInstalled {
         latest: Version,
-        download_info: SophonDownloadInfo,
+        game_download_info: SophonDownloadInfo,
+        asb_download_info: SophonDownloadInfo,
         edition: GameEdition,
 
         downloaded_size: u64,
@@ -253,26 +258,59 @@ impl VersionDiff {
 
     fn download_game(
         &self,
-        download_info: &SophonDownloadInfo,
+        game_download_info: &SophonDownloadInfo,
+        asb_download_info: &SophonDownloadInfo,
         thread_count: usize,
         path: impl AsRef<Path>,
         updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
     ) -> Result<(), <Self as VersionDiffExt>::Error> {
         tracing::debug!(
             path = ?path.as_ref(),
-            info = ?download_info,
+            info = ?game_download_info,
             "Downloading game"
         );
 
         let client = reqwest::blocking::Client::new();
 
-        let mut installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
-        installer.chunks_in_mem = true;
-        installer.chunks_queue_data_limit = Some(2048 * 1024 * 1024); // 2GiB
-        installer.inplace = true;
+        tracing::info_span!("Downloading `asb`").in_scope(|| {
+            let mut installer =
+                SophonInstaller::new(client.clone(), asb_download_info, self.temp_folder())?;
+            installer.chunks_in_mem = true;
+            installer.chunks_queue_data_limit = Some(2048 * 1024 * 1024); // 2GiB
+            installer.inplace = true;
 
-        installer.install(path.as_ref(), thread_count, move |msg| {
-            (updater)(msg.into());
+            let updater_clone = updater.clone();
+            installer.install(path.as_ref(), thread_count, move |msg| {
+                (updater_clone)(msg.into());
+            })?;
+
+            tracing::debug!(
+                temp = ?installer.downloading_temp(),
+                "Removing game downloading cache"
+            );
+
+            let _ = std::fs::remove_dir_all(installer.downloading_temp());
+            Ok::<_, SophonError>(())
+        })?;
+
+        tracing::info_span!("Downloading `game`").in_scope(|| {
+            let mut installer =
+                SophonInstaller::new(client, game_download_info, self.temp_folder())?;
+            installer.chunks_in_mem = true;
+            installer.chunks_queue_data_limit = Some(2048 * 1024 * 1024); // 2GiB
+            installer.inplace = true;
+
+            installer.install(path.as_ref(), thread_count, move |msg| {
+                (updater)(msg.into());
+            })?;
+
+            tracing::debug!(
+                temp = ?installer.downloading_temp(),
+                "Removing game downloading cache"
+            );
+
+            let _ = std::fs::remove_dir_all(installer.downloading_temp());
+            Ok::<_, SophonError>(())
         })?;
 
         // Create `.version` file here even if hdiff patching is failed because
@@ -286,13 +324,6 @@ impl VersionDiff {
 
             std::fs::write(version_path, self.latest().to_string());
         }
-
-        tracing::debug!(
-            temp = ?installer.downloading_temp(),
-            "Removing game downloading cache"
-        );
-
-        let _ = std::fs::remove_dir_all(installer.downloading_temp());
 
         Ok(())
     }
@@ -301,63 +332,111 @@ impl VersionDiff {
         &self,
         from: Version,
         thread_count: usize,
-        diff: &SophonDiff,
+        game_diff: &Option<SophonDiff>,
+        asb_diff: &Option<SophonDiff>,
         path: impl AsRef<Path>,
         updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
     ) -> Result<(), <Self as VersionDiffExt>::Error> {
         tracing::debug!(
             path = ?path.as_ref(),
             from_version = from.to_string(),
-            ?diff,
+            ?game_diff,
             "Patching game files"
         );
 
         let client = reqwest::blocking::Client::new();
 
-        let patcher = SophonPatcher::new(client, diff, self.temp_folder(), None)?;
+        if let Some(asb_diff) = asb_diff {
+            tracing::info_span!("Updating `asb").in_scope(|| {
+                let patcher =
+                    SophonPatcher::new(client.clone(), asb_diff, self.temp_folder(), None)?;
 
-        patcher.update(&path, from.into(), thread_count, move |msg| {
-            (updater)(msg.into());
-        })?;
+                let updater_clone = updater.clone();
+                patcher.update(&path, from.into(), thread_count, move |msg| {
+                    (updater_clone)(msg.into());
+                })?;
 
-        // Create `.version` file here even if hdiff patching is failed because
-        // it's easier to explain user why he should run files repairer than
-        // why he should re-download entire game update because something is failed
-        #[allow(unused_must_use)]
-        {
-            let version_path = self
-                .version_file_path()
-                .unwrap_or(path.as_ref().join(".version"));
+                tracing::debug!(
+                    temp = ?patcher.files_temp(),
+                    "Removing patching cache"
+                );
 
-            std::fs::write(version_path, self.latest().to_string());
+                let _ = std::fs::remove_dir_all(patcher.files_temp());
+                Ok::<_, SophonError>(())
+            })?;
         }
 
-        tracing::debug!(
-            temp = ?patcher.files_temp(),
-            "Removing patching cache"
-        );
+        if let Some(game_diff) = game_diff {
+            tracing::info_span!("Updating `game`").in_scope(|| {
+                let patcher = SophonPatcher::new(client, game_diff, self.temp_folder(), None)?;
 
-        let _ = std::fs::remove_dir_all(patcher.files_temp());
+                patcher.update(&path, from.into(), thread_count, move |msg| {
+                    (updater)(msg.into());
+                })?;
+
+                // Create `.version` file here even if hdiff patching is failed because
+                // it's easier to explain user why he should run files repairer than
+                // why he should re-download entire game update because something is failed
+                #[allow(unused_must_use)]
+                {
+                    let version_path = self
+                        .version_file_path()
+                        .unwrap_or(path.as_ref().join(".version"));
+
+                    std::fs::write(version_path, self.latest().to_string());
+                }
+
+                tracing::debug!(
+                    temp = ?patcher.files_temp(),
+                    "Removing patching cache"
+                );
+
+                let _ = std::fs::remove_dir_all(patcher.files_temp());
+                Ok::<_, SophonError>(())
+            })?;
+        }
 
         Ok(())
     }
 
     fn pre_download(
         &self,
-        download_or_patch_info: &DownloadOrDiff,
+        game_download_or_patch_info: &DownloadOrDiff,
+        asb_download_or_patch_info: &DownloadOrDiff,
         from: Version,
         thread_count: usize,
         updater: impl Fn(<Self as VersionDiffExt>::Update) + Clone + Send + 'static
     ) -> Result<(), <Self as VersionDiffExt>::Error> {
         tracing::debug!(
             from_version = from.to_string(),
-            diff = ?download_or_patch_info,
+            diff = ?game_download_or_patch_info,
             "Predownloading game update"
         );
 
         let client = reqwest::blocking::Client::new();
 
-        match download_or_patch_info {
+        let updater_clone = updater.clone();
+        match game_download_or_patch_info {
+            DownloadOrDiff::Download(download_info) => {
+                let installer =
+                    SophonInstaller::new(client.clone(), download_info, self.temp_folder())?;
+
+                installer.pre_download(thread_count, move |msg| {
+                    (updater_clone)(msg.into());
+                })?;
+            }
+
+            DownloadOrDiff::Patch(diff_info) => {
+                let patcher =
+                    SophonPatcher::new(client.clone(), diff_info, self.temp_folder(), None)?;
+
+                patcher.pre_download(from.into(), thread_count, move |msg| {
+                    (updater_clone)(msg.into());
+                })?;
+            }
+        }
+
+        match asb_download_or_patch_info {
             DownloadOrDiff::Download(download_info) => {
                 let installer = SophonInstaller::new(client, download_info, self.temp_folder())?;
 
@@ -376,35 +455,6 @@ impl VersionDiff {
         }
 
         Ok(())
-    }
-
-    /// Get the matching field value for this diff. Returns none in case of
-    /// [`VersionDiff::Latest`] or [`VersionDiff::Outdated`]
-    pub fn matching_field(&self) -> Option<&str> {
-        match self {
-            Self::Latest {
-                ..
-            }
-            | Self::Outdated {
-                ..
-            } => None,
-            Self::Predownload {
-                download_info, ..
-            } => match download_info {
-                DownloadOrDiff::Patch(SophonDiff {
-                    matching_field, ..
-                })
-                | DownloadOrDiff::Download(SophonDownloadInfo {
-                    matching_field, ..
-                }) => Some(matching_field)
-            },
-            Self::Diff {
-                diff, ..
-            } => Some(&diff.matching_field),
-            Self::NotInstalled {
-                download_info, ..
-            } => Some(&download_info.matching_field)
-        }
     }
 }
 
@@ -631,19 +681,35 @@ impl VersionDiffExt for VersionDiff {
             } => Err(Self::Error::Outdated),
 
             Self::Diff {
-                diff,
+                game_diff,
+                asb_diff,
                 current,
                 ..
-            } => self.patch_game(*current, thread_count, diff, path, updater),
+            } => self.patch_game(*current, thread_count, game_diff, asb_diff, path, updater),
             Self::NotInstalled {
-                download_info, ..
-            } => self.download_game(download_info, thread_count, path, updater),
+                game_download_info,
+                asb_download_info,
+                ..
+            } => self.download_game(
+                game_download_info,
+                asb_download_info,
+                thread_count,
+                path,
+                updater
+            ),
 
             Self::Predownload {
-                download_info,
+                game_download_info,
+                asb_download_info,
                 current,
                 ..
-            } => self.pre_download(download_info, *current, thread_count, updater)
+            } => self.pre_download(
+                game_download_info,
+                asb_download_info,
+                *current,
+                thread_count,
+                updater
+            )
         }
     }
 }

--- a/src/games/star_rail/repairer.rs
+++ b/src/games/star_rail/repairer.rs
@@ -41,7 +41,7 @@ fn try_get_some_integrity_files(
         .find(|download_info| download_info.matching_field == matching_field)
         .ok_or_else(|| {
             anyhow::anyhow!("failed to find game download info")
-                .context("matching field: {matching_field}")
+                .context(format!("matching field: {matching_field}"))
         })?;
 
     let download_manifest = sophon::api::get_download_manifest(&client, download_info)?;

--- a/src/patches/jadeite/metadata.rs
+++ b/src/patches/jadeite/metadata.rs
@@ -3,9 +3,10 @@ use std::cmp::Ordering;
 use serde_json::Value as JsonValue;
 
 use crate::version::Version;
-
 #[cfg(feature = "star-rail")]
 use crate::games::star_rail::consts::GameEdition as StarRailGameEdition;
+#[cfg(feature = "honkai")]
+use crate::games::honkai::consts::GameEdition as Hi3rdGameEdition;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct JadeiteMetadata {
@@ -16,11 +17,13 @@ pub struct JadeiteMetadata {
 impl From<&JsonValue> for JadeiteMetadata {
     fn from(value: &JsonValue) -> Self {
         Self {
-            jadeite: value.get("jadeite")
+            jadeite: value
+                .get("jadeite")
                 .map(JadeitePatchMetadata::from)
                 .unwrap_or_default(),
 
-            games: value.get("games")
+            games: value
+                .get("games")
                 .map(JadeiteGamesMetadata::from)
                 .unwrap_or_default()
         }
@@ -46,7 +49,8 @@ impl From<&JsonValue> for JadeitePatchMetadata {
         let default = Self::default();
 
         Self {
-            version: value.get("version")
+            version: value
+                .get("version")
                 .and_then(|version| version.as_str())
                 .and_then(Version::from_str)
                 .unwrap_or(default.version)
@@ -57,23 +61,20 @@ impl From<&JsonValue> for JadeitePatchMetadata {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct JadeiteGamesMetadata {
     pub hi3rd: JadeiteHi3rdMetadata,
-    pub hsr: JadeiteHsrMetadata,
-    pub wuwa: JadeiteWuwaMetadata
+    pub hsr: JadeiteHsrMetadata
 }
 
 impl From<&JsonValue> for JadeiteGamesMetadata {
     fn from(value: &JsonValue) -> Self {
         Self {
-            hi3rd: value.get("hi3rd")
+            hi3rd: value
+                .get("hi3rd")
                 .map(JadeiteHi3rdMetadata::from)
                 .unwrap_or_default(),
 
-            hsr: value.get("hsr")
+            hsr: value
+                .get("hsr")
                 .map(JadeiteHsrMetadata::from)
-                .unwrap_or_default(),
-
-            wuwa: value.get("wuwa")
-                .map(JadeiteWuwaMetadata::from)
                 .unwrap_or_default()
         }
     }
@@ -92,29 +93,49 @@ pub struct JadeiteHi3rdMetadata {
 impl From<&JsonValue> for JadeiteHi3rdMetadata {
     fn from(value: &JsonValue) -> Self {
         Self {
-            global: value.get("global")
+            global: value
+                .get("global")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            sea: value.get("sea")
+            sea: value
+                .get("sea")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            china: value.get("china")
+            china: value
+                .get("china")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            taiwan: value.get("taiwan")
+            taiwan: value
+                .get("taiwan")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            korea: value.get("korea")
+            korea: value
+                .get("korea")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            japan: value.get("japan")
+            japan: value
+                .get("japan")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default()
+        }
+    }
+}
+
+#[cfg(feature = "honkai")]
+impl JadeiteHi3rdMetadata {
+    pub fn for_edition(&self, edition: Hi3rdGameEdition) -> JadeitePatchStatus {
+        match edition {
+            Hi3rdGameEdition::Global => self.global,
+            Hi3rdGameEdition::Sea => self.sea,
+            Hi3rdGameEdition::China => self.china,
+            Hi3rdGameEdition::Taiwan => self.taiwan,
+            Hi3rdGameEdition::Korea => self.korea,
+            Hi3rdGameEdition::Japan => self.japan
         }
     }
 }
@@ -128,31 +149,13 @@ pub struct JadeiteHsrMetadata {
 impl From<&JsonValue> for JadeiteHsrMetadata {
     fn from(value: &JsonValue) -> Self {
         Self {
-            global: value.get("global")
+            global: value
+                .get("global")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default(),
 
-            china: value.get("china")
-                .map(JadeitePatchStatus::from)
-                .unwrap_or_default()
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub struct JadeiteWuwaMetadata {
-    pub global: JadeitePatchStatus,
-    pub china: JadeitePatchStatus
-}
-
-impl From<&JsonValue> for JadeiteWuwaMetadata {
-    fn from(value: &JsonValue) -> Self {
-        Self {
-            global: value.get("global")
-                .map(JadeitePatchStatus::from)
-                .unwrap_or_default(),
-
-            china: value.get("china")
+            china: value
+                .get("china")
                 .map(JadeitePatchStatus::from)
                 .unwrap_or_default()
         }
@@ -190,12 +193,14 @@ impl From<&JsonValue> for JadeitePatchStatus {
         let default = Self::default();
 
         Self {
-            status: value.get("status")
+            status: value
+                .get("status")
                 .and_then(|status| status.as_str())
                 .map(JadeitePatchStatusVariant::from)
                 .unwrap_or(default.status),
 
-            version: value.get("version")
+            version: value
+                .get("version")
                 .and_then(|version| version.as_str())
                 .and_then(Version::from_str)
                 .unwrap_or(default.version)
@@ -210,7 +215,8 @@ impl JadeitePatchStatus {
             // Metadata game version is lower than the one we gave here,
             // so some predictions are needed
             Ordering::Less => match self.status {
-                // Even if the patch was verified - return that it's not verified, at least because the game was updated
+                // Even if the patch was verified - return that it's not verified, at least because
+                // the game was updated
                 JadeitePatchStatusVariant::Verified => JadeitePatchStatusVariant::Unverified,
 
                 // If the patch wasn't verified - keep it unverified
@@ -240,31 +246,31 @@ impl JadeitePatchStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum JadeitePatchStatusVariant {
     /// Patch is verified and works fine
-    /// 
+    ///
     /// Value: `verified`
     Verified,
 
     /// Patch is not verified to be working
-    /// 
+    ///
     /// Value: `unverified`
     Unverified,
 
     /// Patch doesn't work
-    /// 
+    ///
     /// Value: `broken`
     Broken,
 
     /// Patch is working but unsafe for use
-    /// 
+    ///
     /// You can't run the game with this status
-    /// 
+    ///
     /// Value: `unsafe`
     Unsafe,
 
     /// Patch is working but we have some concerns about it
-    /// 
+    ///
     /// You still can run the game with this status
-    /// 
+    ///
     /// Value: `concerning`
     Concerning
 }
@@ -279,10 +285,10 @@ impl Default for JadeitePatchStatusVariant {
 impl From<&str> for JadeitePatchStatusVariant {
     fn from(value: &str) -> Self {
         match value {
-            "verified"   => Self::Verified,
+            "verified" => Self::Verified,
             "unverified" => Self::Unverified,
-            "broken"     => Self::Broken,
-            "unsafe"     => Self::Unsafe,
+            "broken" => Self::Broken,
+            "unsafe" => Self::Unsafe,
             "concerning" => Self::Concerning,
 
             // Not really a good practice but it's unlikely to happen anyway


### PR DESCRIPTION
No voiceovers, uses `game` and `asb` components. For the sake of version detection, `game` is downloaded *after* `asb`. Also enabled support for predownload, but unsure if that ever appears in the API.