### PR TITLE
Improve empty dir check

### DIFF
--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -174,7 +174,7 @@ impl Game {
 
                 Err(err) => {
                     if self.path.exists() {
-                        if !self.path.is_dir() {
+                        if !self.path.metadata()?.is_dir() {
                             anyhow::bail!("Path is not a directory: {}", self.path.display());
                         }
                         if self

--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -173,7 +173,19 @@ impl Game {
                 Ok(version) => version,
 
                 Err(err) => {
-                    if self.path.exists() && self.path.metadata()?.len() == 0 {
+                    if self.path.exists() {
+                        if !self.path.is_dir() {
+                            anyhow::bail!("Path is not a directory: {}", self.path.display());
+                        }
+                        if self
+                            .path
+                            .read_dir()
+                            .context(format!("Checking game dir: {}", self.path.display()))?
+                            .count()
+                            > 0
+                        {
+                            anyhow::bail!("Game directory is not empty")
+                        }
                         let game_downloads = sophon::api::get_game_download_sophon_info(
                             &client,
                             branch_info

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -126,7 +126,19 @@ impl Game {
             let current = match self.get_version() {
                 Ok(version) => version,
                 Err(err) => {
-                    if self.path.exists() && self.path.metadata()?.len() == 0 {
+                    if self.path.exists() {
+                        if !self.path.is_dir() {
+                            anyhow::bail!("Path is not a directory: {}", self.path.display());
+                        }
+                        if self
+                            .path
+                            .read_dir()
+                            .context(format!("Checking game dir: {}", self.path.display()))?
+                            .count()
+                            > 0
+                        {
+                            anyhow::bail!("Game directory is not empty")
+                        }
                         let game_downloads = sophon::api::get_game_download_sophon_info(
                             &client,
                             branch_info

--- a/src/games/honkai/game.rs
+++ b/src/games/honkai/game.rs
@@ -127,7 +127,7 @@ impl Game {
                 Ok(version) => version,
                 Err(err) => {
                     if self.path.exists() {
-                        if !self.path.is_dir() {
+                        if !self.path.metadata()?.is_dir() {
                             anyhow::bail!("Path is not a directory: {}", self.path.display());
                         }
                         if self

--- a/src/games/star_rail/game.rs
+++ b/src/games/star_rail/game.rs
@@ -168,7 +168,19 @@ impl Game {
             let current = match self.get_version() {
                 Ok(version) => version,
                 Err(err) => {
-                    if self.path.exists() && self.path.metadata()?.len() == 0 {
+                    if self.path.exists() {
+                        if !self.path.is_dir() {
+                            anyhow::bail!("Path is not a directory: {}", self.path.display());
+                        }
+                        if self
+                            .path
+                            .read_dir()
+                            .context(format!("Checking game dir: {}", self.path.display()))?
+                            .count()
+                            > 0
+                        {
+                            anyhow::bail!("Game directory is not empty")
+                        }
                         let game_downloads = sophon::api::get_game_download_sophon_info(
                             &client,
                             branch_info

--- a/src/games/star_rail/game.rs
+++ b/src/games/star_rail/game.rs
@@ -169,7 +169,7 @@ impl Game {
                 Ok(version) => version,
                 Err(err) => {
                     if self.path.exists() {
-                        if !self.path.is_dir() {
+                        if !self.path.metadata()?.is_dir() {
                             anyhow::bail!("Path is not a directory: {}", self.path.display());
                         }
                         if self

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 use crate::version::Version;
 use crate::traits::prelude::*;
 use super::api;
@@ -109,7 +111,19 @@ impl Game {
             let current = match self.get_version() {
                 Ok(version) => version,
                 Err(err) => {
-                    if self.path.exists() && self.path.metadata()?.len() == 0 {
+                    if self.path.exists() {
+                        if !self.path.is_dir() {
+                            anyhow::bail!("Path is not a directory: {}", self.path.display());
+                        }
+                        if self
+                            .path
+                            .read_dir()
+                            .context(format!("Checking game dir: {}", self.path.display()))?
+                            .count()
+                            > 0
+                        {
+                            anyhow::bail!("Game directory is not empty")
+                        }
                         let downloaded_size = response
                             .main
                             .major

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -112,7 +112,7 @@ impl Game {
                 Ok(version) => version,
                 Err(err) => {
                     if self.path.exists() {
-                        if !self.path.is_dir() {
+                        if !self.path.metadata()?.is_dir() {
                             anyhow::bail!("Path is not a directory: {}", self.path.display());
                         }
                         if self


### PR DESCRIPTION
an empty directory can still have size above 0, it is not a reliable way to check for an empty directory. Added a couple more checks with descriptive error messages.

- checks for whether the game path is a directory or a symlink pointing to a directory
- checks whether the dir is empty (and an error message saying the dir is not empty when it is not empty)